### PR TITLE
feat(auth): memoize auth verification call

### DIFF
--- a/.changeset/new-grapes-own.md
+++ b/.changeset/new-grapes-own.md
@@ -1,0 +1,7 @@
+---
+"@deepdish/workbench": minor
+"@deepdish/nextjs": minor
+"@deepdish/ui": minor
+---
+
+Added authentication request memoization.

--- a/packages/nextjs/src/middleware.ts
+++ b/packages/nextjs/src/middleware.ts
@@ -16,16 +16,16 @@ export function deepdishMiddleware(
   return async (request) => {
     const { url, method } = request
 
-    if (url.includes('/__deepdish/')) {
-      if (url.endsWith('/sign-in') && method === 'GET') {
+    if (url.includes('/__deepdish/') && method === 'GET') {
+      if (url.endsWith('/sign-in')) {
         return config.signIn(request)
       }
 
-      if (url.endsWith('/sign-out') && method === 'GET') {
+      if (url.endsWith('/sign-out')) {
         return config.signOut(request)
       }
 
-      if (url.endsWith('/verify') && method === 'POST') {
+      if (url.endsWith('/verify')) {
         const verified = await config.verify(request)
         return NextResponse.json({ signedIn: verified })
       }

--- a/packages/ui/src/deepdish.tsx
+++ b/packages/ui/src/deepdish.tsx
@@ -1,7 +1,6 @@
 import 'server-only'
 
 import { getLogger } from '@logtape/logtape'
-// TODO: should `next` be a peer dependency?
 import { headers } from 'next/headers'
 import { getBaseUrl, getContract } from './config/config'
 import { Menu } from './menu'
@@ -26,7 +25,6 @@ async function canEdit() {
   }
 
   const response = await fetch(`${baseUrl.data}/__deepdish/verify`, {
-    method: 'POST',
     headers: await headers(),
   })
 

--- a/packages/workbench/src/client.tsx
+++ b/packages/workbench/src/client.tsx
@@ -18,11 +18,9 @@ declare global {
 async function authenticate() {
   const verification = await withResult(
     async () => {
-      const response = await fetch('/__deepdish/verify', {
-        method: 'POST',
-      })
-
+      const response = await fetch('/__deepdish/verify')
       const body = await response.json()
+
       return body.signedIn
     },
     (error) => new Error('Authentication failed.', { cause: error }),


### PR DESCRIPTION
This memoizes the server-side authentication call. Next.js [memoizes GET requests automatically](https://nextjs.org/docs/app/building-your-application/caching#request-memoization). In order to take advantage of that automatic memoization, this work changes the `/__deepdish/verify` call to use the `GET` HTTP verb instead of `POST`. Now, only one call to `/__deepdish/verify` should be made on a server render.

Resolves DEEP-208.