### PR TITLE
feat(nextjs): add draft mode conditional

### DIFF
--- a/.changeset/three-buses-clean.md
+++ b/.changeset/three-buses-clean.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/nextjs": patch
+---
+
+Added middleware pass-through.

--- a/packages/nextjs/environment.d.ts
+++ b/packages/nextjs/environment.d.ts
@@ -1,0 +1,5 @@
+namespace NodeJS {
+  interface ProcessEnv {
+    DEEPDISH_MODE: string
+  }
+}

--- a/packages/nextjs/src/middleware.ts
+++ b/packages/nextjs/src/middleware.ts
@@ -14,6 +14,10 @@ export function deepdishMiddleware(
   config: DeepdishMiddlewareConfig,
 ): NextMiddleware {
   return async (request) => {
+    if (process.env.DEEPDISH_MODE !== 'draft') {
+      return NextResponse.next()
+    }
+
     const { url, method } = request
 
     if (url.includes('/__deepdish/') && method === 'GET') {


### PR DESCRIPTION
Ensures the Next.js middleware passes through when the app is not configured for draft mode.

Closes DEEP-210.