### PR TITLE
chore(packages): inject environment dependencies

### DIFF
--- a/.changeset/curvy-goats-whisper.md
+++ b/.changeset/curvy-goats-whisper.md
@@ -1,0 +1,6 @@
+---
+"@deepdish/nextjs": patch
+"@deepdish/ui": patch
+---
+
+Removed implicit environment dependencies.

--- a/.changeset/little-carrots-fold.md
+++ b/.changeset/little-carrots-fold.md
@@ -1,0 +1,6 @@
+---
+"@deepdish/marketing": patch
+"@deepdish/demo": patch
+---
+
+Supplied mode setting to configurable dependencies.

--- a/.changeset/little-carrots-fold.md
+++ b/.changeset/little-carrots-fold.md
@@ -3,4 +3,4 @@
 "@deepdish/demo": patch
 ---
 
-Supplied mode setting to configurable dependencies.
+Supplied environment-specific values to configurable dependencies.

--- a/apps/demo/.env
+++ b/apps/demo/.env
@@ -1,2 +1,1 @@
-BASE_URL=http://localhost:4000
 DEEPDISH_MODE=draft

--- a/apps/demo/.env.development
+++ b/apps/demo/.env.development
@@ -1,0 +1,1 @@
+BASE_URL=http://localhost:4000

--- a/apps/demo/environment.d.ts
+++ b/apps/demo/environment.d.ts
@@ -1,6 +1,6 @@
 namespace NodeJS {
   interface ProcessEnv {
     BASE_URL: string
-    DEEPDISH_MODE: string
+    DEEPDISH_MODE?: 'draft'
   }
 }

--- a/apps/demo/src/cms/index.ts
+++ b/apps/demo/src/cms/index.ts
@@ -27,7 +27,10 @@ export async function cms() {
   await init()
 
   return await configure({
-    baseUrl: process.env.BASE_URL,
+    settings: {
+      baseUrl: process.env.BASE_URL,
+      draft: process.env.DEEPDISH_MODE === 'draft',
+    },
     contracts: {
       typography: {
         resolver: createJsonResolver(contentPath, typographySchema, {

--- a/apps/demo/src/cms/index.ts
+++ b/apps/demo/src/cms/index.ts
@@ -27,16 +27,19 @@ export async function cms() {
   await init()
 
   return await configure({
-    settings: {
-      baseUrl: process.env.BASE_URL,
-      draft: process.env.DEEPDISH_MODE === 'draft',
-    },
     contracts: {
       typography: {
         resolver: createJsonResolver(contentPath, typographySchema, {
           maxBatchSize: 10,
         }),
       },
+    },
+    logging: {
+      enabled: process.env.NODE_ENV === 'development',
+    },
+    settings: {
+      baseUrl: process.env.BASE_URL,
+      draft: process.env.DEEPDISH_MODE === 'draft',
     },
   })
 }

--- a/apps/demo/src/middleware.ts
+++ b/apps/demo/src/middleware.ts
@@ -1,6 +1,8 @@
 import { deepdishMiddleware } from '@deepdish/nextjs'
 import { NextResponse } from 'next/server'
 
+const draft = process.env.DEEPDISH_MODE === 'draft'
+
 let signedIn = false
 
 async function signIn() {
@@ -23,6 +25,7 @@ async function verify() {
 }
 
 export default deepdishMiddleware({
+  draft,
   signIn,
   signOut,
   verify,

--- a/apps/marketing/environment.d.ts
+++ b/apps/marketing/environment.d.ts
@@ -4,6 +4,7 @@ namespace NodeJS {
     DEEPDISH_CLOUD_OAUTH_CLIENT_ID: string
     DEEPDISH_CLOUD_OAUTH_REDIRECT_URI: string
     DEEPDISH_CLOUD_STATE: string
+    DEEPDISH_MODE?: 'draft'
     DEEPDISH_PROJECT_ALIAS: string
     DEEPDISH_SECRET_KEY: string
   }

--- a/apps/marketing/src/middleware.ts
+++ b/apps/marketing/src/middleware.ts
@@ -7,6 +7,7 @@ const endpoint = process.env.DEEPDISH_CLOUD_ENDPOINT
 const clientId = process.env.DEEPDISH_CLOUD_OAUTH_CLIENT_ID
 const redirectUri = process.env.DEEPDISH_CLOUD_OAUTH_REDIRECT_URI
 const state = process.env.DEEPDISH_CLOUD_STATE
+const draft = process.env.DEEPDISH_MODE === 'draft'
 const projectAlias = process.env.DEEPDISH_PROJECT_ALIAS
 const secretKey = process.env.DEEPDISH_SECRET_KEY
 
@@ -62,6 +63,7 @@ function signOut() {
 }
 
 export default deepdishMiddleware({
+  draft,
   verify,
   signIn,
   signOut,

--- a/biome.json
+++ b/biome.json
@@ -59,6 +59,16 @@
           }
         }
       }
+    },
+    {
+      "include": ["packages/**"],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "noProcessEnv": "error"
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/nextjs/environment.d.ts
+++ b/packages/nextjs/environment.d.ts
@@ -1,5 +1,0 @@
-namespace NodeJS {
-  interface ProcessEnv {
-    DEEPDISH_MODE: string
-  }
-}

--- a/packages/nextjs/src/middleware.ts
+++ b/packages/nextjs/src/middleware.ts
@@ -5,6 +5,7 @@ import {
 } from 'next/server'
 
 export type DeepdishMiddlewareConfig = {
+  draft: boolean
   verify: (request: NextRequest) => boolean | Promise<boolean>
   signIn: (request: NextRequest) => NextResponse | Promise<NextResponse>
   signOut: (request: NextRequest) => NextResponse | Promise<NextResponse>
@@ -14,7 +15,7 @@ export function deepdishMiddleware(
   config: DeepdishMiddlewareConfig,
 ): NextMiddleware {
   return async (request) => {
-    if (process.env.DEEPDISH_MODE !== 'draft') {
+    if (!config.draft) {
       return NextResponse.next()
     }
 

--- a/packages/ui/src/config/config.ts
+++ b/packages/ui/src/config/config.ts
@@ -6,17 +6,19 @@ import { configureLogging } from './logging'
 
 const logger = getLogger(['deepdish', 'config'])
 
-type Settings = {
+type Contracts = Readonly<{
+  [T in ValueType]?: Contract<T>
+}>
+
+type Settings = Readonly<{
   baseUrl: string
   draft: boolean
-}
+}>
 
-export type Config = {
+export type Config = Readonly<{
+  contracts: Contracts
   settings: Settings
-  contracts: {
-    readonly [T in ValueType]?: Contract<T>
-  }
-}
+}>
 
 let config: Config
 

--- a/packages/ui/src/config/config.ts
+++ b/packages/ui/src/config/config.ts
@@ -6,8 +6,13 @@ import { configureLogging } from './logging'
 
 const logger = getLogger(['deepdish', 'config'])
 
+type Settings = {
+  draft: boolean
+}
+
 export type Config = {
   baseUrl: string
+  settings: Settings
   contracts: {
     readonly [T in ValueType]?: Contract<T>
   }
@@ -60,4 +65,12 @@ export function getBaseUrl(): Result<string> {
   }
 
   return { data: config.baseUrl }
+}
+
+export function getSettings(): Result<Settings> {
+  if (!config) {
+    return notConfigured()
+  }
+
+  return { data: config.settings }
 }

--- a/packages/ui/src/config/config.ts
+++ b/packages/ui/src/config/config.ts
@@ -7,11 +7,11 @@ import { configureLogging } from './logging'
 const logger = getLogger(['deepdish', 'config'])
 
 type Settings = {
+  baseUrl: string
   draft: boolean
 }
 
 export type Config = {
-  baseUrl: string
   settings: Settings
   contracts: {
     readonly [T in ValueType]?: Contract<T>
@@ -57,14 +57,6 @@ export function getContract<T extends ValueType>(type: T): Result<Contract<T>> {
   }
 
   return { data: contract }
-}
-
-export function getBaseUrl(): Result<string> {
-  if (!config) {
-    return notConfigured()
-  }
-
-  return { data: config.baseUrl }
 }
 
 export function getSettings(): Result<Settings> {

--- a/packages/ui/src/config/config.ts
+++ b/packages/ui/src/config/config.ts
@@ -41,7 +41,7 @@ export async function configure(input: Config): Promise<Result<void>> {
 
   config = Object.freeze(input)
 
-  await configureLogging()
+  await configureLogging(true)
 
   logger.info('DeepDish configured successfully.')
   return { data: undefined }

--- a/packages/ui/src/config/config.ts
+++ b/packages/ui/src/config/config.ts
@@ -10,6 +10,10 @@ type Contracts = Readonly<{
   [T in ValueType]?: Contract<T>
 }>
 
+type Logging = Readonly<{
+  enabled: boolean
+}>
+
 type Settings = Readonly<{
   baseUrl: string
   draft: boolean
@@ -17,6 +21,7 @@ type Settings = Readonly<{
 
 export type Config = Readonly<{
   contracts: Contracts
+  logging: Logging
   settings: Settings
 }>
 
@@ -41,7 +46,7 @@ export async function configure(input: Config): Promise<Result<void>> {
 
   config = Object.freeze(input)
 
-  await configureLogging(true)
+  await configureLogging(config.logging.enabled)
 
   logger.info('DeepDish configured successfully.')
   return { data: undefined }

--- a/packages/ui/src/config/contract.ts
+++ b/packages/ui/src/config/contract.ts
@@ -1,6 +1,6 @@
 import type { Resolver } from '@deepdish/resolvers'
 import type { ValueMap, ValueType } from '../schemas'
 
-export type Contract<T extends ValueType> = {
-  readonly resolver: Resolver<ValueMap[T]>
-}
+export type Contract<T extends ValueType> = Readonly<{
+  resolver: Resolver<ValueMap[T]>
+}>

--- a/packages/ui/src/config/logging.ts
+++ b/packages/ui/src/config/logging.ts
@@ -4,8 +4,6 @@ import {
   getConsoleSink,
 } from '@logtape/logtape'
 
-const isDevelopment = process.env.NODE_ENV === 'development'
-
 export async function configureLogging() {
   await configure({
     sinks: {
@@ -19,13 +17,13 @@ export async function configureLogging() {
     loggers: [
       {
         category: ['logtape', 'meta'],
-        sinks: isDevelopment ? ['console'] : [],
+        sinks: ['console'],
         level: 'warning',
       },
       {
         category: ['deepdish'],
-        sinks: isDevelopment ? ['console'] : [],
-        level: isDevelopment ? 'debug' : 'info',
+        sinks: ['console'],
+        level: 'debug',
       },
     ],
   })

--- a/packages/ui/src/config/logging.ts
+++ b/packages/ui/src/config/logging.ts
@@ -4,7 +4,7 @@ import {
   getConsoleSink,
 } from '@logtape/logtape'
 
-export async function configureLogging(isDevelopment: boolean) {
+export async function configureLogging(enabled: boolean) {
   await configure({
     sinks: {
       console: getConsoleSink({
@@ -17,13 +17,13 @@ export async function configureLogging(isDevelopment: boolean) {
     loggers: [
       {
         category: ['logtape', 'meta'],
-        sinks: isDevelopment ? ['console'] : [],
+        sinks: enabled ? ['console'] : [],
         level: 'warning',
       },
       {
         category: ['deepdish'],
-        sinks: isDevelopment ? ['console'] : [],
-        level: isDevelopment ? 'debug' : 'info',
+        sinks: enabled ? ['console'] : [],
+        level: enabled ? 'debug' : null,
       },
     ],
   })

--- a/packages/ui/src/config/logging.ts
+++ b/packages/ui/src/config/logging.ts
@@ -4,7 +4,7 @@ import {
   getConsoleSink,
 } from '@logtape/logtape'
 
-export async function configureLogging() {
+export async function configureLogging(isDevelopment: boolean) {
   await configure({
     sinks: {
       console: getConsoleSink({
@@ -17,13 +17,13 @@ export async function configureLogging() {
     loggers: [
       {
         category: ['logtape', 'meta'],
-        sinks: ['console'],
+        sinks: isDevelopment ? ['console'] : [],
         level: 'warning',
       },
       {
         category: ['deepdish'],
-        sinks: ['console'],
-        level: 'debug',
+        sinks: isDevelopment ? ['console'] : [],
+        level: isDevelopment ? 'debug' : 'info',
       },
     ],
   })

--- a/packages/ui/src/deepdish.tsx
+++ b/packages/ui/src/deepdish.tsx
@@ -3,7 +3,7 @@ import 'server-only'
 import { Shell } from '@deepdish/core/shell'
 import { getLogger } from '@logtape/logtape'
 import { headers } from 'next/headers'
-import { getBaseUrl, getContract, getSettings } from './config/config'
+import { getContract, getSettings } from './config/config'
 import { Menu } from './menu'
 import type { ValueType } from './schemas'
 import type {
@@ -25,13 +25,7 @@ async function canEdit() {
     return false
   }
 
-  const baseUrl = getBaseUrl()
-
-  if (baseUrl.failure) {
-    return false
-  }
-
-  const response = await fetch(`${baseUrl.data}/__deepdish/verify`, {
+  const response = await fetch(`${settings.baseUrl}/__deepdish/verify`, {
     headers: await headers(),
   })
 

--- a/packages/ui/src/deepdish.tsx
+++ b/packages/ui/src/deepdish.tsx
@@ -3,7 +3,7 @@ import 'server-only'
 import { Shell } from '@deepdish/core/shell'
 import { getLogger } from '@logtape/logtape'
 import { headers } from 'next/headers'
-import { getBaseUrl, getContract } from './config/config'
+import { getBaseUrl, getContract, getSettings } from './config/config'
 import { Menu } from './menu'
 import type { ValueType } from './schemas'
 import type {
@@ -15,7 +15,13 @@ import type {
 const logger = getLogger(['deepdish', 'ui'])
 
 async function canEdit() {
-  if (process.env.DEEPDISH_MODE !== 'draft') {
+  const settingsResult = getSettings()
+  if (settingsResult.failure) {
+    return false
+  }
+  const settings = settingsResult.data
+
+  if (!settings.draft) {
     return false
   }
 


### PR DESCRIPTION
This [disallows](https://biomejs.dev/linter/rules/no-process-env/) packages to implicitly reference environment variables—defined by the application using the package—in favor of explicit dependencies supplied via dependency injection.

In other words, an application can configure and reference environment variables, but a package cannot. Instead, a package can declare what values it requires, and the application can supply them as necessary.