### PR TITLE
fix(cms): add peer dependency

### DIFF
--- a/.changeset/good-ravens-smash.md
+++ b/.changeset/good-ravens-smash.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/cms": patch
+---
+
+Added `next` peer dependency.

--- a/apps/demo/src/app/layout.tsx
+++ b/apps/demo/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { contentPath, initContent } from '@/content'
-import { DeepDishProvider, deepdish } from '@deepdish/cms'
+import { DeepDishProvider } from '@deepdish/cms'
 import { createJsonResolver } from '@deepdish/resolvers/json'
+import { configure } from '@deepdish/ui/config'
 import { typographySchema } from '@deepdish/ui/schemas'
 import type { Metadata } from 'next'
 import localFont from 'next/font/local'
@@ -8,7 +9,7 @@ import './globals.css'
 
 await initContent()
 
-await deepdish({
+await configure({
   contracts: {
     typography: {
       resolver: createJsonResolver(contentPath, typographySchema, {

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -37,6 +37,9 @@
     "@types/react": "18.3.3",
     "tsup": "8.2.4"
   },
+  "peerDependencies": {
+    "next": "^15"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Fixes the demo app. Our `cms` package was missing the `next` peer dependency, which was causing `tsup` to create some weird build artifacts that broke Next.js. The demo app was also importing the wrong configuration function. 