### PR TITLE
refactor: replace Zod with Valibot

### DIFF
--- a/.changeset/eight-geckos-destroy.md
+++ b/.changeset/eight-geckos-destroy.md
@@ -2,4 +2,4 @@
 "@deepdish/core": minor
 ---
 
-Consolidated schema types.
+Consolidated schema-related types.

--- a/.changeset/eight-geckos-destroy.md
+++ b/.changeset/eight-geckos-destroy.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/core": minor
+---
+
+Consolidated schema types.

--- a/.changeset/perfect-goats-warn.md
+++ b/.changeset/perfect-goats-warn.md
@@ -1,0 +1,7 @@
+---
+"@deepdish/resolvers": minor
+"@deepdish/ui": minor
+"@deepdish/demo": minor
+---
+
+Replaced Zod with Valibot.

--- a/.cspell/tooling.txt
+++ b/.cspell/tooling.txt
@@ -1,6 +1,6 @@
 biomejs
-csvg
 cpath
+csvg
 dashify
 excalidraw
 filenaming
@@ -8,13 +8,14 @@ flox
 happydom
 lockb
 logtape
-posthog
 nextjs
+posthog
 registrator
 rehype
 shadcn
 tsup
-turborepo
 turbopack
+turborepo
+vali
 valibot
 vercel

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -15,7 +15,7 @@
     "next": "15.1.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "zod": "3.23.8"
+    "valibot": "1.0.0-rc.0"
   },
   "devDependencies": {
     "@types/node": "20.14.2",

--- a/apps/demo/src/cms.ts
+++ b/apps/demo/src/cms.ts
@@ -2,14 +2,14 @@ import { contentPaths, initContent } from '@/content'
 import { createJsonResolver } from '@deepdish/resolvers/json'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
-import { z } from 'zod'
+import * as v from 'valibot'
 
-const featureSchema = z.object({
-  name: z.string(),
-  description: z.string(),
+const featureSchema = v.object({
+  name: v.string(),
+  description: v.string(),
 })
 
-const textSchema = z.string()
+const textSchema = v.string()
 
 const contracts = {
   text: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,10 @@
       "import": "./dist/context.js",
       "types": "./dist/context.d.ts"
     },
+    "./schema": {
+      "import": "./dist/schema.js",
+      "types": "./dist/schema.d.ts"
+    },
     "./shell": {
       "import": "./dist/shell.js",
       "types": "./dist/shell.d.ts"
@@ -23,6 +27,7 @@
   },
   "dependencies": {
     "react": "catalog:react",
+    "valibot": "1.0.0-rc.0",
     "zustand": "5.0.3"
   },
   "devDependencies": {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,0 +1,5 @@
+import type { GenericSchema, InferOutput } from 'valibot'
+
+export type Schema = GenericSchema
+
+export type Value<S extends Schema> = InferOutput<S>

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,5 +1,6 @@
-import type { GenericSchema, InferOutput } from 'valibot'
+import type { BaseIssue, BaseSchema, InferOutput } from 'valibot'
 
-export type Schema = GenericSchema
+// biome-ignore lint/suspicious/noExplicitAny: generic schema type requires output type of any
+export type Schema<S = unknown> = BaseSchema<S, any, BaseIssue<unknown>>
 
 export type Value<S extends Schema> = InferOutput<S>

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig([
   {
-    entry: ['src/context.tsx', 'src/shell.tsx'],
+    entry: ['src/context.tsx', 'src/schema.ts', 'src/shell.tsx'],
     format: ['esm'],
     sourcemap: true,
     dts: true,

--- a/packages/resolvers/package.json
+++ b/packages/resolvers/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@byteslice/result": "0.1.0",
+    "@deepdish/core": "workspace:0.4.0",
     "dataloader": "2.2.2",
     "valibot": "1.0.0-rc.0"
   },

--- a/packages/resolvers/package.json
+++ b/packages/resolvers/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@byteslice/result": "0.1.0",
     "dataloader": "2.2.2",
-    "zod": "3.23.8"
+    "valibot": "1.0.0-rc.0"
   },
   "devDependencies": {
     "@types/bun": "catalog:repo",

--- a/packages/resolvers/src/json.ts
+++ b/packages/resolvers/src/json.ts
@@ -1,6 +1,6 @@
 import type { PathLike as Path } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
-import type { ZodTypeAny } from 'zod'
+import type * as v from 'valibot'
 import { type Key, type ResolverOptions, createResolver } from './resolver'
 
 async function parseJson(path: Path) {
@@ -37,7 +37,7 @@ function listKeys(path: Path) {
 }
 
 /** Creates a resolver to asynchronously read/write values of a JSON file. */
-export function createJsonResolver<S extends ZodTypeAny>(
+export function createJsonResolver<S extends v.UnknownSchema>(
   path: Path,
   schema: S,
   options?: ResolverOptions,

--- a/packages/resolvers/src/json.ts
+++ b/packages/resolvers/src/json.ts
@@ -37,7 +37,7 @@ function listKeys(path: Path) {
 }
 
 /** Creates a resolver to asynchronously read/write values of a JSON file. */
-export function createJsonResolver<S extends v.UnknownSchema>(
+export function createJsonResolver<S extends v.GenericSchema>(
   path: Path,
   schema: S,
   options?: ResolverOptions,

--- a/packages/resolvers/src/json.ts
+++ b/packages/resolvers/src/json.ts
@@ -1,6 +1,6 @@
 import type { PathLike as Path } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
-import type * as v from 'valibot'
+import type { Schema } from '@deepdish/core/schema'
 import { type Key, type ResolverOptions, createResolver } from './resolver'
 
 async function parseJson(path: Path) {
@@ -37,7 +37,7 @@ function listKeys(path: Path) {
 }
 
 /** Creates a resolver to asynchronously read/write values of a JSON file. */
-export function createJsonResolver<S extends v.GenericSchema>(
+export function createJsonResolver<S extends Schema>(
   path: Path,
   schema: S,
   options?: ResolverOptions,

--- a/packages/resolvers/src/resolver.test.ts
+++ b/packages/resolvers/src/resolver.test.ts
@@ -1,12 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import fs from 'node:fs/promises'
-import { z } from 'zod'
+import * as v from 'valibot'
 import { createJsonResolver } from './json'
 import { createResolver } from './resolver'
 
 const path = './test.json'
 const empty = JSON.stringify({})
-const schema = z.string()
+const schema = v.string()
 const key = 'foo'
 const value = 'bar'
 const error = new Error('uh-oh')

--- a/packages/resolvers/src/resolver.ts
+++ b/packages/resolvers/src/resolver.ts
@@ -1,6 +1,6 @@
 import { type Result, withResult } from '@byteslice/result'
 import DataLoader, { type BatchLoadFn } from 'dataloader'
-import { ZodError, type ZodTypeAny, type z } from 'zod'
+import * as v from 'valibot'
 
 export type Key = string
 
@@ -34,11 +34,11 @@ function handleValidationException(ex: unknown) {
   return new Error('Unable to validate content.', { cause: ex })
 }
 
-export function createResolver<S extends ZodTypeAny>(
+export function createResolver<S extends v.UnknownSchema>(
   schema: S,
   options?: ResolverOptions,
 ) {
-  type Value = z.infer<S>
+  type Value = v.InferOutput<S>
 
   return (
     loadValues: BatchLoadFn<Key, unknown>,
@@ -79,7 +79,7 @@ export function createResolver<S extends ZodTypeAny>(
         }
 
         const validateResult = await withResult<unknown, ReadFailure>(
-          () => schema.parse(content),
+          () => v.parse(schema, content),
           (error) => ({ type: 'CONTENT_INVALID', error }),
           { onException: handleValidationException },
         )

--- a/packages/resolvers/src/resolver.ts
+++ b/packages/resolvers/src/resolver.ts
@@ -78,16 +78,16 @@ export function createResolver<S extends v.GenericSchema>(
           return { failure: { type: 'CONTENT_MISSING' } }
         }
 
-        const validateResult = await withResult<unknown, ReadFailure>(
+        const parseResult = await withResult<Value, ReadFailure>(
           () => v.parse(schema, content),
           (error) => ({ type: 'CONTENT_INVALID', error }),
           { onException: handleValidationException },
         )
-        if (validateResult.failure) {
-          return validateResult
+        if (parseResult.failure) {
+          return parseResult
         }
 
-        return { data: content }
+        return { data: parseResult.data }
       },
       async write(ctx, value) {
         const key = options?.deriveKey ? options.deriveKey(ctx) : ctx.key

--- a/packages/resolvers/src/resolver.ts
+++ b/packages/resolvers/src/resolver.ts
@@ -25,9 +25,9 @@ export type ResolverOptions = {
   maxBatchSize?: number
 }
 
-function handleValidationException(ex: unknown) {
-  if (ex instanceof ZodError) {
-    const message = [ex.flatten().formErrors].join('; ')
+function handleValidationException(ex: unknown): Error {
+  if (ex instanceof v.ValiError) {
+    const message = ex.issues.map((issue) => issue.message).join('; ')
     return new Error(message, { cause: ex })
   }
 

--- a/packages/resolvers/src/resolver.ts
+++ b/packages/resolvers/src/resolver.ts
@@ -34,7 +34,7 @@ function handleValidationException(ex: unknown) {
   return new Error('Unable to validate content.', { cause: ex })
 }
 
-export function createResolver<S extends v.UnknownSchema>(
+export function createResolver<S extends v.GenericSchema>(
   schema: S,
   options?: ResolverOptions,
 ) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,7 +56,7 @@
     "remark-rehype": "11.1.0",
     "server-only": "0.0.1",
     "unified": "11.0.5",
-    "zod": "3.23.8"
+    "valibot": "1.0.0-rc.0"
   },
   "devDependencies": {
     "@tsconfig/create-react-app": "2.0.5",

--- a/packages/ui/src/config/components.tsx
+++ b/packages/ui/src/config/components.tsx
@@ -1,5 +1,6 @@
+import type { Schema, Value } from '@deepdish/core/schema'
 import { DeepDish } from '../deepdish'
-import type { Contracts, Schema, Value } from './contract'
+import type { Contracts } from './contract'
 
 type Schemas<C extends Contracts> = {
   [K in keyof C]: C[K]['schema']

--- a/packages/ui/src/config/config.ts
+++ b/packages/ui/src/config/config.ts
@@ -1,6 +1,7 @@
 import type { Result } from '@byteslice/result'
+import type { Schema } from '@deepdish/core/schema'
 import { getLogger } from '@logtape/logtape'
-import type { Contract, Contracts, Schema } from './contract'
+import type { Contract, Contracts } from './contract'
 import { configureLogging } from './logging'
 
 const logger = getLogger(['deepdish', 'config'])

--- a/packages/ui/src/config/contract.ts
+++ b/packages/ui/src/config/contract.ts
@@ -1,7 +1,7 @@
 import type { Resolver } from '@deepdish/resolvers'
 import type * as v from 'valibot'
 
-export type Schema = v.UnknownSchema
+export type Schema = v.GenericSchema
 
 export type Value<S extends Schema> = v.InferOutput<S>
 

--- a/packages/ui/src/config/contract.ts
+++ b/packages/ui/src/config/contract.ts
@@ -1,9 +1,9 @@
 import type { Resolver } from '@deepdish/resolvers'
-import type { ZodTypeAny, z } from 'zod'
+import type * as v from 'valibot'
 
-export type Schema = ZodTypeAny
+export type Schema = v.UnknownSchema
 
-export type Value<S extends Schema> = z.infer<S>
+export type Value<S extends Schema> = v.InferOutput<S>
 
 export type Contract<S extends Schema> = {
   resolver: Resolver<Value<S>>

--- a/packages/ui/src/config/contract.ts
+++ b/packages/ui/src/config/contract.ts
@@ -1,9 +1,5 @@
+import type { Schema, Value } from '@deepdish/core/schema'
 import type { Resolver } from '@deepdish/resolvers'
-import type * as v from 'valibot'
-
-export type Schema = v.GenericSchema
-
-export type Value<S extends Schema> = v.InferOutput<S>
 
 export type Contract<S extends Schema> = {
   resolver: Resolver<Value<S>>

--- a/packages/ui/src/deepdish.tsx
+++ b/packages/ui/src/deepdish.tsx
@@ -145,7 +145,7 @@ async function DeepDishElement<V>(props: {
   }
 
   if (!(await canEdit())) {
-    return props.render(readResult.data)
+    return props.render(readResult.data as V)
   }
 
   return (
@@ -155,7 +155,7 @@ async function DeepDishElement<V>(props: {
         value={readResult.data}
         onUpdate={handleUpdate(props.deepdish.contract, props.deepdish.key)}
       >
-        {props.render(readResult.data)}
+        {props.render(readResult.data as V)}
       </Menu>
     </Shell>
   )

--- a/packages/ui/src/deepdish.tsx
+++ b/packages/ui/src/deepdish.tsx
@@ -145,7 +145,7 @@ async function DeepDishElement<V>(props: {
   }
 
   if (!(await canEdit())) {
-    return props.render(readResult.data as V)
+    return props.render(readResult.data)
   }
 
   return (
@@ -155,7 +155,7 @@ async function DeepDishElement<V>(props: {
         value={readResult.data}
         onUpdate={handleUpdate(props.deepdish.contract, props.deepdish.key)}
       >
-        {props.render(readResult.data as V)}
+        {props.render(readResult.data)}
       </Menu>
     </Shell>
   )

--- a/packages/ui/src/elements/link.tsx
+++ b/packages/ui/src/elements/link.tsx
@@ -1,5 +1,6 @@
 import 'server-only'
 
+import type { Value } from '@deepdish/core/schema'
 import * as v from 'valibot'
 import { DeepDish } from '../deepdish'
 import type { ElementProps } from '../types'
@@ -10,7 +11,7 @@ export const linkSchema = v.object({
   title: v.optional(v.string()),
 })
 
-type LinkValue = v.InferOutput<typeof linkSchema>
+type LinkValue = Value<typeof linkSchema>
 
 export function Link(props: ElementProps<'a', string>) {
   return (

--- a/packages/ui/src/elements/link.tsx
+++ b/packages/ui/src/elements/link.tsx
@@ -1,16 +1,16 @@
 import 'server-only'
 
-import { z } from 'zod'
+import * as v from 'valibot'
 import { DeepDish } from '../deepdish'
 import type { ElementProps } from '../types'
 
-export const linkSchema = z.object({
-  destination: z.string().optional(),
-  href: z.string().optional(),
-  title: z.string().optional(),
+export const linkSchema = v.object({
+  destination: v.optional(v.string()),
+  href: v.optional(v.string()),
+  title: v.optional(v.string()),
 })
 
-type LinkValue = z.infer<typeof linkSchema>
+type LinkValue = v.InferOutput<typeof linkSchema>
 
 export function Link(props: ElementProps<'a', string>) {
   return (

--- a/packages/ui/src/elements/media.tsx
+++ b/packages/ui/src/elements/media.tsx
@@ -1,15 +1,15 @@
 import 'server-only'
 
-import { z } from 'zod'
+import * as v from 'valibot'
 import { DeepDish } from '../deepdish'
 import type { ElementProps } from '../types'
 
-export const audioSchema = z.object({
-  fallback: z.string().optional(),
-  source: z.string().optional(),
+export const audioSchema = v.object({
+  fallback: v.optional(v.string()),
+  source: v.optional(v.string()),
 })
 
-type AudioValue = z.infer<typeof audioSchema>
+type AudioValue = v.InferOutput<typeof audioSchema>
 
 export function Audio(props: ElementProps<'audio', string>) {
   return (
@@ -30,13 +30,13 @@ export function Audio(props: ElementProps<'audio', string>) {
   )
 }
 
-export const imageSchema = z.object({
-  description: z.string().optional(),
-  source: z.string().optional(),
-  title: z.string().optional(),
+export const imageSchema = v.object({
+  description: v.optional(v.string()),
+  source: v.optional(v.string()),
+  title: v.optional(v.string()),
 })
 
-type ImageValue = z.infer<typeof imageSchema>
+type ImageValue = v.InferOutput<typeof imageSchema>
 
 export function Image(props: ElementProps<'img'>) {
   return (
@@ -61,12 +61,12 @@ export function Image(props: ElementProps<'img'>) {
   )
 }
 
-export const videoSchema = z.object({
-  fallback: z.string().optional(),
-  source: z.string().optional(),
+export const videoSchema = v.object({
+  fallback: v.optional(v.string()),
+  source: v.optional(v.string()),
 })
 
-type VideoValue = z.infer<typeof videoSchema>
+type VideoValue = v.InferOutput<typeof videoSchema>
 
 export function Video(props: ElementProps<'video', string>) {
   return (

--- a/packages/ui/src/elements/media.tsx
+++ b/packages/ui/src/elements/media.tsx
@@ -1,5 +1,6 @@
 import 'server-only'
 
+import type { Value } from '@deepdish/core/schema'
 import * as v from 'valibot'
 import { DeepDish } from '../deepdish'
 import type { ElementProps } from '../types'
@@ -9,7 +10,7 @@ export const audioSchema = v.object({
   source: v.optional(v.string()),
 })
 
-type AudioValue = v.InferOutput<typeof audioSchema>
+type AudioValue = Value<typeof audioSchema>
 
 export function Audio(props: ElementProps<'audio', string>) {
   return (
@@ -36,7 +37,7 @@ export const imageSchema = v.object({
   title: v.optional(v.string()),
 })
 
-type ImageValue = v.InferOutput<typeof imageSchema>
+type ImageValue = Value<typeof imageSchema>
 
 export function Image(props: ElementProps<'img'>) {
   return (
@@ -66,7 +67,7 @@ export const videoSchema = v.object({
   source: v.optional(v.string()),
 })
 
-type VideoValue = v.InferOutput<typeof videoSchema>
+type VideoValue = Value<typeof videoSchema>
 
 export function Video(props: ElementProps<'video', string>) {
   return (

--- a/packages/ui/src/elements/typography.tsx
+++ b/packages/ui/src/elements/typography.tsx
@@ -1,13 +1,13 @@
 import 'server-only'
 
-import { z } from 'zod'
+import * as v from 'valibot'
 import { type ContentFormat, sanitizeContent } from '../content'
 import { DeepDish } from '../deepdish'
 import type { ElementProps, IntrinsicElement } from '../types'
 
-export const typographySchema = z.string()
+export const typographySchema = v.string()
 
-type TypographyValue = z.infer<typeof typographySchema>
+type TypographyValue = v.InferOutput<typeof typographySchema>
 
 type TypographyProps<E extends IntrinsicElement> = ElementProps<E, string> & {
   format?: ContentFormat

--- a/packages/ui/src/elements/typography.tsx
+++ b/packages/ui/src/elements/typography.tsx
@@ -1,5 +1,6 @@
 import 'server-only'
 
+import type { Value } from '@deepdish/core/schema'
 import * as v from 'valibot'
 import { type ContentFormat, sanitizeContent } from '../content'
 import { DeepDish } from '../deepdish'
@@ -7,7 +8,7 @@ import type { ElementProps, IntrinsicElement } from '../types'
 
 export const typographySchema = v.string()
 
-type TypographyValue = v.InferOutput<typeof typographySchema>
+type TypographyValue = Value<typeof typographySchema>
 
 type TypographyProps<E extends IntrinsicElement> = ElementProps<E, string> & {
   format?: ContentFormat

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
-      zod:
-        specifier: 3.23.8
-        version: 3.23.8
+      valibot:
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(typescript@5.5.4)
     devDependencies:
       '@types/node':
         specifier: 20.14.2
@@ -320,9 +320,9 @@ importers:
       dataloader:
         specifier: 2.2.2
         version: 2.2.2
-      zod:
-        specifier: 3.23.8
-        version: 3.23.8
+      valibot:
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(typescript@5.6.3)
     devDependencies:
       '@types/bun':
         specifier: catalog:repo
@@ -430,9 +430,9 @@ importers:
       unified:
         specifier: 11.0.5
         version: 11.0.5
-      zod:
-        specifier: 3.23.8
-        version: 3.23.8
+      valibot:
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(typescript@5.6.3)
     devDependencies:
       '@tsconfig/create-react-app':
         specifier: 2.0.5
@@ -2829,6 +2829,7 @@ packages:
 
   bun@1.2.4:
     resolution: {integrity: sha512-ZY0EZ/UKqheaLeAtMsfJA6jWoWvV9HAtfFaOJSmS3LrNpFKs1Sg5fZLSsczN1h3a+Dtheo4O3p3ZYWrf40kRGw==}
+    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -9049,6 +9050,10 @@ snapshots:
       react: 19.0.0
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.0.0-rc.0(typescript@5.5.4):
+    optionalDependencies:
+      typescript: 5.5.4
 
   valibot@1.0.0-rc.0(typescript@5.6.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       react:
         specifier: catalog:react
         version: 19.0.0
+      valibot:
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(typescript@5.7.3)
       zustand:
         specifier: 5.0.3
         version: 5.0.3(@types/react@18.3.3)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
@@ -317,6 +320,9 @@ importers:
       '@byteslice/result':
         specifier: 0.1.0
         version: 0.1.0
+      '@deepdish/core':
+        specifier: workspace:0.4.0
+        version: link:../core
       dataloader:
         specifier: 2.2.2
         version: 2.2.2
@@ -2829,7 +2835,6 @@ packages:
 
   bun@1.2.4:
     resolution: {integrity: sha512-ZY0EZ/UKqheaLeAtMsfJA6jWoWvV9HAtfFaOJSmS3LrNpFKs1Sg5fZLSsczN1h3a+Dtheo4O3p3ZYWrf40kRGw==}
-    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -9058,6 +9063,10 @@ snapshots:
   valibot@1.0.0-rc.0(typescript@5.6.3):
     optionalDependencies:
       typescript: 5.6.3
+
+  valibot@1.0.0-rc.0(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
This replaces [Zod](https://zod.dev/) with [Valibot](https://valibot.dev/).

Additionally, schema-related types have been consolidated within the `@deepdish/core` package.

Resolves DEEP-230