### PR TITLE
fix(ui): export pre-built schemas

### DIFF
--- a/.changeset/big-kiwis-complain.md
+++ b/.changeset/big-kiwis-complain.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/ui": minor
+---
+
+Consolidated pre-built schemas export.

--- a/.changeset/happy-shoes-work.md
+++ b/.changeset/happy-shoes-work.md
@@ -1,5 +1,6 @@
 ---
 "@deepdish/marketing": minor
+"@deepdish/cms": minor
 ---
 
 Updated pre-built schema imports.

--- a/.changeset/proud-bears-tie.md
+++ b/.changeset/proud-bears-tie.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/marketing": minor
+---
+
+Updated pre-built schema imports.

--- a/apps/marketing/src/cms/index.ts
+++ b/apps/marketing/src/cms/index.ts
@@ -1,6 +1,6 @@
 import { getBaseUrl } from '@/lib/get-base-url'
 import { configure } from '@deepdish/ui/config'
-import { typographySchema } from '@deepdish/ui/typography'
+import { typographySchema } from '@deepdish/ui/schemas'
 import { cookieResolver } from '../resolver'
 
 let configured = false

--- a/apps/marketing/src/resolver.ts
+++ b/apps/marketing/src/resolver.ts
@@ -1,5 +1,5 @@
 import { type Context, createResolver } from '@deepdish/resolvers'
-import { typographySchema } from '@deepdish/ui/typography'
+import { typographySchema } from '@deepdish/ui/schema'
 import type { NextRequest, NextResponse } from 'next/server'
 
 const data = new Map<string, string>()

--- a/apps/marketing/src/resolver.ts
+++ b/apps/marketing/src/resolver.ts
@@ -1,5 +1,5 @@
 import { type Context, createResolver } from '@deepdish/resolvers'
-import { typographySchema } from '@deepdish/ui/schema'
+import { typographySchema } from '@deepdish/ui/schemas'
 import type { NextRequest, NextResponse } from 'next/server'
 
 const data = new Map<string, string>()

--- a/packages/cms/src/cms.ts
+++ b/packages/cms/src/cms.ts
@@ -1,6 +1,6 @@
 import { createTypographyResolver } from '@deepdish-cloud/resolvers/typography'
 import { configure } from '@deepdish/ui/config'
-import { typographySchema } from '@deepdish/ui/typography'
+import { typographySchema } from '@deepdish/ui/schemas'
 import { deepdishMiddleware } from './middleware'
 import { ProviderContainer as DeepDishProvider } from './provider/container'
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,10 @@
       "import": "./dist/elements/media.js",
       "types": "./dist/elements/media.d.ts"
     },
+    "./schemas": {
+      "import": "./dist/schemas.js",
+      "types": "./dist/schemas.d.ts"
+    },
     "./typography": {
       "import": "./dist/elements/typography.js",
       "types": "./dist/elements/typography.d.ts"

--- a/packages/ui/src/elements/link.tsx
+++ b/packages/ui/src/elements/link.tsx
@@ -1,17 +1,8 @@
 import 'server-only'
 
-import type { Value } from '@deepdish/core/schema'
-import * as v from 'valibot'
 import { DeepDish } from '../deepdish'
 import type { ElementProps } from '../types'
-
-export const linkSchema = v.object({
-  destination: v.optional(v.string()),
-  href: v.optional(v.string()),
-  title: v.optional(v.string()),
-})
-
-type LinkValue = Value<typeof linkSchema>
+import type { LinkValue } from '../schemas'
 
 export function Link(props: ElementProps<'a', string>) {
   return (

--- a/packages/ui/src/elements/link.tsx
+++ b/packages/ui/src/elements/link.tsx
@@ -1,8 +1,8 @@
 import 'server-only'
 
 import { DeepDish } from '../deepdish'
-import type { ElementProps } from '../types'
 import type { LinkValue } from '../schemas'
+import type { ElementProps } from '../types'
 
 export function Link(props: ElementProps<'a', string>) {
   return (

--- a/packages/ui/src/elements/media.tsx
+++ b/packages/ui/src/elements/media.tsx
@@ -1,8 +1,8 @@
 import 'server-only'
 
 import { DeepDish } from '../deepdish'
-import type { ElementProps } from '../types'
 import type { AudioValue, ImageValue, VideoValue } from '../schemas'
+import type { ElementProps } from '../types'
 
 export function Audio(props: ElementProps<'audio', string>) {
   return (

--- a/packages/ui/src/elements/media.tsx
+++ b/packages/ui/src/elements/media.tsx
@@ -1,16 +1,8 @@
 import 'server-only'
 
-import type { Value } from '@deepdish/core/schema'
-import * as v from 'valibot'
 import { DeepDish } from '../deepdish'
 import type { ElementProps } from '../types'
-
-export const audioSchema = v.object({
-  fallback: v.optional(v.string()),
-  source: v.optional(v.string()),
-})
-
-type AudioValue = Value<typeof audioSchema>
+import type { AudioValue, ImageValue, VideoValue } from '../schemas'
 
 export function Audio(props: ElementProps<'audio', string>) {
   return (
@@ -30,14 +22,6 @@ export function Audio(props: ElementProps<'audio', string>) {
     />
   )
 }
-
-export const imageSchema = v.object({
-  description: v.optional(v.string()),
-  source: v.optional(v.string()),
-  title: v.optional(v.string()),
-})
-
-type ImageValue = Value<typeof imageSchema>
 
 export function Image(props: ElementProps<'img'>) {
   return (
@@ -61,13 +45,6 @@ export function Image(props: ElementProps<'img'>) {
     />
   )
 }
-
-export const videoSchema = v.object({
-  fallback: v.optional(v.string()),
-  source: v.optional(v.string()),
-})
-
-type VideoValue = Value<typeof videoSchema>
 
 export function Video(props: ElementProps<'video', string>) {
   return (

--- a/packages/ui/src/elements/typography.tsx
+++ b/packages/ui/src/elements/typography.tsx
@@ -1,14 +1,9 @@
 import 'server-only'
 
-import type { Value } from '@deepdish/core/schema'
-import * as v from 'valibot'
 import { type ContentFormat, sanitizeContent } from '../content'
 import { DeepDish } from '../deepdish'
 import type { ElementProps, IntrinsicElement } from '../types'
-
-export const typographySchema = v.string()
-
-type TypographyValue = Value<typeof typographySchema>
+import type { TypographyValue } from '../schemas'
 
 type TypographyProps<E extends IntrinsicElement> = ElementProps<E, string> & {
   format?: ContentFormat

--- a/packages/ui/src/elements/typography.tsx
+++ b/packages/ui/src/elements/typography.tsx
@@ -2,8 +2,8 @@ import 'server-only'
 
 import { type ContentFormat, sanitizeContent } from '../content'
 import { DeepDish } from '../deepdish'
-import type { ElementProps, IntrinsicElement } from '../types'
 import type { TypographyValue } from '../schemas'
+import type { ElementProps, IntrinsicElement } from '../types'
 
 type TypographyProps<E extends IntrinsicElement> = ElementProps<E, string> & {
   format?: ContentFormat

--- a/packages/ui/src/schemas.ts
+++ b/packages/ui/src/schemas.ts
@@ -1,0 +1,36 @@
+import type { Value } from '@deepdish/core/schema'
+import * as v from 'valibot'
+
+export const audioSchema = v.object({
+  fallback: v.optional(v.string()),
+  source: v.optional(v.string()),
+})
+
+export type AudioValue = Value<typeof audioSchema>
+
+export const imageSchema = v.object({
+  description: v.optional(v.string()),
+  source: v.optional(v.string()),
+  title: v.optional(v.string()),
+})
+
+export type ImageValue = Value<typeof imageSchema>
+
+export const linkSchema = v.object({
+  destination: v.optional(v.string()),
+  href: v.optional(v.string()),
+  title: v.optional(v.string()),
+})
+
+export type LinkValue = Value<typeof linkSchema>
+
+export const typographySchema = v.string()
+
+export type TypographyValue = Value<typeof typographySchema>
+
+export const videoSchema = v.object({
+  fallback: v.optional(v.string()),
+  source: v.optional(v.string()),
+})
+
+export type VideoValue = Value<typeof videoSchema>

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig([
   {
-    entry: ['src/config/config.ts', 'src/content.ts'],
+    entry: ['src/config/config.ts', 'src/content.ts', 'src/schemas.ts'],
     format: ['esm'],
     sourcemap: true,
     target: 'esnext',


### PR DESCRIPTION
Collocating and exporting pre-built schemas with their associate elements was causing environment-related issues.

This work reintroduces the named `schemas` export from the `@deepdish/ui` package.