### PR TITLE
feat(ui): automatically apply contract lookup

### DIFF
--- a/.changeset/empty-dancers-stay.md
+++ b/.changeset/empty-dancers-stay.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/ui": minor
+---
+
+Applied contract lookup to created components.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ export default deepdishMiddleware(config);
 
 ### Step 5: Add a DeepDish Component
 
-To add a DeepDish component to your page, import one and pass it a `deepdish` prop. That object requires a `key` to uniquely identify the component and a `contract` to specify the structure of its data.
+To add a DeepDish component to your page, import one and pass it a `deepdish` prop. That object requires a `key` to uniquely identify the component.
 
 ```tsx
 import { Header1 } from "@/deepdish";
@@ -132,7 +132,7 @@ import { Header1 } from "@/deepdish";
 function Home() {
   return (
     <div>
-      <Header1 deepdish={{ key: "title", contract: "typography" }}>
+      <Header1 deepdish={{ key: "title" }}>
         Header Fallback
       </Header1>
     </div>

--- a/apps/demo/src/app/page.tsx
+++ b/apps/demo/src/app/page.tsx
@@ -5,12 +5,12 @@ export default function Demo() {
     <div className="flex flex-col px-8 py-6 gap-4">
       <div className="flex flex-col gap-1 max-w-prose">
         <Text
-          deepdish={{ key: 'headline', contract: 'text' }}
+          deepdish={{ key: 'headline' }}
           fallback="DeepDish Demo"
           render={async (value) => <p className="text-xl font-bold">{value}</p>}
         />
         <Text
-          deepdish={{ key: 'sub-headline', contract: 'text' }}
+          deepdish={{ key: 'sub-headline' }}
           fallback="DeepDish is an alternative to traditional CMS systems. The code looks
           like normal React, but every element is editable. First, log in with
           the Workbench below. Then, simply right-click on elements and edit the
@@ -22,14 +22,14 @@ export default function Demo() {
         <div>
           <p className="font-bold">Nested elements</p>
           <Text
-            deepdish={{ key: 'parent', contract: 'text' }}
+            deepdish={{ key: 'parent' }}
             fallback="This is a parent element."
             render={async (parent) => {
               return (
                 <>
                   <h1>{parent}</h1>
                   <Text
-                    deepdish={{ key: 'child', contract: 'text' }}
+                    deepdish={{ key: 'child' }}
                     fallback="This is a child element."
                     render={async (child) => {
                       return <p>{child}</p>
@@ -45,7 +45,6 @@ export default function Demo() {
           <Text
             deepdish={{
               collection: ['collection-1', 'collection-2'],
-              contract: 'text',
             }}
             fallback="This is a static collection."
             render={async (value) => <p>{value}</p>}
@@ -54,7 +53,7 @@ export default function Demo() {
         <div>
           <p className="font-bold">Dynamic collection</p>
           <Text
-            deepdish={{ collection: '*', contract: 'text' }}
+            deepdish={{ collection: '*' }}
             fallback="This is a dynamic collection."
             render={async (value) => <p>{value}</p>}
           />
@@ -62,9 +61,7 @@ export default function Demo() {
       </div>
       <div>
         <p className="font-bold">Custom elements</p>
-        <Feature
-          deepdish={{ key: 'features/feature-1', contract: 'feature' }}
-        />
+        <Feature deepdish={{ key: 'features/feature-1' }} />
       </div>
     </div>
   )

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
       <section className="pt-16 pb-24 sm:pt-24 sm:pb-32 border-b border-gray-200 bg-textured">
         <div className="container mx-auto text-left sm:text-center max-w-xl">
           <Text
-            deepdish={{ key: 'home/headline', contract: 'text' }}
+            deepdish={{ key: 'home/headline' }}
             fallback="Manage content directly on your pages"
             render={async (value) => (
               <h1 className="text-4xl font-bold mb-6 bg-gradient-to-r from-red-400 to-orange-500 text-transparent bg-clip-text">
@@ -20,7 +20,7 @@ export default function Home() {
             )}
           />
           <Text
-            deepdish={{ key: 'home/sub-headline', contract: 'text' }}
+            deepdish={{ key: 'home/sub-headline' }}
             fallback="DeepDish lets you build Next.js apps without integrating a CMS."
             render={async (value) => (
               <p className="text-xl text-gray-800 mb-10 max-w-2xl mx-auto">

--- a/packages/ui/src/config/components.tsx
+++ b/packages/ui/src/config/components.tsx
@@ -16,9 +16,9 @@ type Components<C extends Contracts, S extends Schemas<C>> = {
 
 export function createComponents<C extends Contracts>(contracts: C) {
   const components = {} as Components<C, Schemas<C>>
-  for (const key in contracts) {
-    type V = Value<C[typeof key]['schema']>
-    components[key] = DeepDish<V>
+  for (const name in contracts) {
+    type V = Value<C[typeof name]['schema']>
+    components[name] = DeepDish<V>
   }
 
   return components

--- a/packages/ui/src/config/components.tsx
+++ b/packages/ui/src/config/components.tsx
@@ -7,7 +7,7 @@ type Schemas<C extends Contracts> = {
 }
 
 type Component<S extends Schema> = React.FC<
-  React.ComponentProps<typeof DeepDish<Value<S>>>
+  Omit<React.ComponentProps<typeof DeepDish<Value<S>>>, 'contract'>
 >
 
 type Components<C extends Contracts, S extends Schemas<C>> = {
@@ -18,7 +18,9 @@ export function createComponents<C extends Contracts>(contracts: C) {
   const components = {} as Components<C, Schemas<C>>
   for (const name in contracts) {
     type V = Value<C[typeof name]['schema']>
-    components[name] = DeepDish<V>
+    components[name] = (props) => {
+      return <DeepDish<V> {...props} contract={name} />
+    }
   }
 
   return components

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -1,19 +1,15 @@
 type Key = string
 
-type Contract = string
-
 type Pattern = string
 
 type Collection = Pattern | Key[]
 
 export type DeepDishCollectionProps = {
   collection: Collection
-  contract: Contract
 }
 
 export type DeepDishElementProps = {
   collection?: never
-  contract: Contract
   key: Key
 }
 


### PR DESCRIPTION
When DeepDish components are created, they will automatically have their `contract` lookup provided. This will eliminate the need for developers to specify prop manually.

Resolves DEEP-247