### PR TITLE
feat(config): add `meta` support

### DIFF
--- a/apps/demo/src/cms.tsx
+++ b/apps/demo/src/cms.tsx
@@ -2,7 +2,7 @@ import { contentPaths, initContent } from '@/content'
 import { createJsonResolver } from '@deepdish/resolvers/json'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
-import { createContract, type Contracts } from '@deepdish/ui/contract'
+import { type Contracts, createContract } from '@deepdish/ui/contract'
 import type { DeepDishProps } from '@deepdish/ui/deepdish'
 import * as v from 'valibot'
 

--- a/apps/demo/src/cms.tsx
+++ b/apps/demo/src/cms.tsx
@@ -2,6 +2,7 @@ import { contentPaths, initContent } from '@/content'
 import { createJsonResolver } from '@deepdish/resolvers/json'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
+import { createContract, type Contracts } from '@deepdish/ui/contract'
 import type { DeepDishProps } from '@deepdish/ui/deepdish'
 import * as v from 'valibot'
 
@@ -12,6 +13,14 @@ const featureSchema = v.object({
 
 const textSchema = v.string()
 
+const featureResolver = createJsonResolver(
+  contentPaths.feature,
+  featureSchema,
+  {
+    maxBatchSize: 10,
+  },
+)
+
 const contracts = {
   text: {
     resolver: createJsonResolver(contentPaths.text, textSchema, {
@@ -19,13 +28,12 @@ const contracts = {
     }),
     schema: textSchema,
   },
-  feature: {
-    resolver: createJsonResolver(contentPaths.feature, featureSchema, {
-      maxBatchSize: 10,
-    }),
-    schema: featureSchema,
-  },
-}
+  feature: createContract(featureSchema, featureResolver, {
+    name: {
+      rich: true,
+    },
+  }),
+} as unknown as Contracts
 
 async function cms() {
   await initContent()

--- a/apps/demo/src/cms.tsx
+++ b/apps/demo/src/cms.tsx
@@ -11,8 +11,6 @@ const featureSchema = v.object({
   description: v.string(),
 })
 
-const textSchema = v.string()
-
 const featureResolver = createJsonResolver(
   contentPaths.feature,
   featureSchema,
@@ -21,13 +19,14 @@ const featureResolver = createJsonResolver(
   },
 )
 
+const textSchema = v.string()
+
+const textResolver = createJsonResolver(contentPaths.text, textSchema, {
+  maxBatchSize: 10,
+})
+
 const contracts = {
-  text: {
-    resolver: createJsonResolver(contentPaths.text, textSchema, {
-      maxBatchSize: 10,
-    }),
-    schema: textSchema,
-  },
+  text: createContract(textSchema, textResolver),
   feature: createContract(featureSchema, featureResolver, {
     name: {
       rich: true,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,5 +1,11 @@
 import type { BaseIssue, BaseSchema, InferOutput } from 'valibot'
 
+export type Meta<S extends Schema> = {
+  [K in keyof Value<S>]?: {
+    rich?: boolean
+  }
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: generic schema type requires output type of any
 export type Schema<S = unknown> = BaseSchema<S, any, BaseIssue<unknown>>
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,10 @@
       "import": "./dist/config/config.js",
       "types": "./dist/config/config.d.ts"
     },
+    "./contract": {
+      "import": "./dist/config/contract.js",
+      "types": "./dist/config/contract.d.ts"
+    },
     "./deepdish": {
       "import": "./dist/deepdish.js",
       "types": "./dist/deepdish.d.ts"

--- a/packages/ui/src/config/contract.ts
+++ b/packages/ui/src/config/contract.ts
@@ -1,11 +1,5 @@
-import type { Schema, Value } from '@deepdish/core/schema'
+import type { Meta, Schema, Value } from '@deepdish/core/schema'
 import type { Resolver } from '@deepdish/resolvers'
-
-type Meta<S extends Schema> = {
-  [K in keyof Value<S>]?: {
-    rich?: boolean
-  }
-}
 
 export type Contract<S extends Schema> = {
   resolver: Resolver<Value<S>>

--- a/packages/ui/src/config/contract.ts
+++ b/packages/ui/src/config/contract.ts
@@ -1,9 +1,28 @@
 import type { Schema, Value } from '@deepdish/core/schema'
 import type { Resolver } from '@deepdish/resolvers'
 
+type Meta<S extends Schema> = {
+  [K in keyof Value<S>]?: {
+    rich?: boolean
+  }
+}
+
 export type Contract<S extends Schema> = {
   resolver: Resolver<Value<S>>
   schema: S
+  meta?: Meta<S>
 }
 
 export type Contracts = Record<string, Contract<Schema>>
+
+export function createContract<S extends Schema>(
+  schema: S,
+  resolver: Resolver<Value<S>>,
+  meta?: Meta<S>,
+): Contract<S> {
+  return {
+    resolver,
+    schema,
+    meta,
+  }
+}

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig([
   {
-    entry: ['src/config/config.ts', 'src/content.ts'],
+    entry: ['src/config/config.ts', 'src/config/contract.ts', 'src/content.ts'],
     format: ['esm'],
     sourcemap: true,
     target: 'esnext',


### PR DESCRIPTION
This lets developers define meta data about their schema, which will be needed for the Workbench and other features down the road. This adds a `createContract` helper, which adds some nice type safety to the returned `meta` object, guaranteeing that the only keys available on that `meta` object are defined within the specified schema.