### PR TITLE
feat(core): add schema building helpers

### DIFF
--- a/.changeset/forty-rats-design.md
+++ b/.changeset/forty-rats-design.md
@@ -1,0 +1,6 @@
+---
+"@deepdish/workbench": patch
+"@deepdish/cms": patch
+---
+
+Added error suppression to schema serialization.

--- a/.changeset/small-clubs-flow.md
+++ b/.changeset/small-clubs-flow.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/core": patch
+---
+
+Added schema-building helpers.

--- a/.changeset/small-clubs-flow.md
+++ b/.changeset/small-clubs-flow.md
@@ -1,5 +1,5 @@
 ---
-"@deepdish/core": patch
+"@deepdish/core": minor
 ---
 
 Added schema-building helpers.

--- a/.changeset/wide-clubs-speak.md
+++ b/.changeset/wide-clubs-speak.md
@@ -1,0 +1,6 @@
+---
+"@deepdish/marketing": patch
+"@deepdish/demo": patch
+---
+
+Replaced valibot with core schema helpers.

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -9,13 +9,13 @@
   },
   "dependencies": {
     "@deepdish/cms": "workspace:0.9.0",
+    "@deepdish/core": "workspace:0.5.0",
     "@deepdish/nextjs": "workspace:0.9.0",
     "@deepdish/resolvers": "workspace:0.14.0",
     "@deepdish/ui": "workspace:0.16.0",
     "next": "15.1.4",
     "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "valibot": "1.0.0-rc.0"
+    "react-dom": "19.0.0"
   },
   "devDependencies": {
     "@types/node": "20.14.2",

--- a/apps/demo/src/cms.tsx
+++ b/apps/demo/src/cms.tsx
@@ -1,18 +1,18 @@
 import { contentPaths, initContent } from '@/content'
-import { createSchema } from '@deepdish/core/schema'
+import { schema } from '@deepdish/core/schema'
 import { createJsonResolver } from '@deepdish/resolvers/json'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
 import type { DeepDishProps } from '@deepdish/ui/deepdish'
 
-const featureSchema = createSchema((v, utils) =>
+const featureSchema = schema((v, utils) =>
   v.object({
     name: v.string(),
     description: utils.meta(v.string(), { rich: true }),
   }),
 )
 
-const textSchema = createSchema((v) => v.string())
+const textSchema = schema((v) => v.string())
 
 const contracts = {
   text: {

--- a/apps/demo/src/cms.tsx
+++ b/apps/demo/src/cms.tsx
@@ -3,14 +3,16 @@ import { createJsonResolver } from '@deepdish/resolvers/json'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
 import type { DeepDishProps } from '@deepdish/ui/deepdish'
-import * as v from 'valibot'
+import { createSchema } from '@deepdish/core/schema'
 
-const featureSchema = v.object({
-  name: v.string(),
-  description: v.string(),
-})
+const featureSchema = createSchema((v, utils) =>
+  v.object({
+    name: v.string(),
+    description: utils.meta(v.string(), { rich: true }),
+  }),
+)
 
-const textSchema = v.string()
+const textSchema = createSchema((v) => v.string())
 
 const contracts = {
   text: {

--- a/apps/demo/src/cms.tsx
+++ b/apps/demo/src/cms.tsx
@@ -1,9 +1,9 @@
 import { contentPaths, initContent } from '@/content'
+import { createSchema } from '@deepdish/core/schema'
 import { createJsonResolver } from '@deepdish/resolvers/json'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
 import type { DeepDishProps } from '@deepdish/ui/deepdish'
-import { createSchema } from '@deepdish/core/schema'
 
 const featureSchema = createSchema((v, utils) =>
   v.object({

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@clerk/nextjs": "6.11.2",
     "@deepdish/cms": "workspace:0.9.0",
+    "@deepdish/core": "workspace:0.5.0",
     "@deepdish/nextjs": "workspace:0.9.0",
     "@deepdish/resolvers": "workspace:0.14.0",
     "@deepdish/ui": "workspace:0.16.0",
@@ -34,8 +35,7 @@
     "react-dom": "19.0.0",
     "react-syntax-highlighter": "15.6.1",
     "tailwind-merge": "2.3.0",
-    "tailwindcss-animate": "1.0.7",
-    "valibot": "1.0.0-rc.0"
+    "tailwindcss-animate": "1.0.7"
   },
   "devDependencies": {
     "@tsconfig/next": "2.0.3",

--- a/apps/marketing/src/cms.ts
+++ b/apps/marketing/src/cms.ts
@@ -1,10 +1,10 @@
 import { getBaseUrl } from '@/lib/get-base-url'
-import { createSchema } from '@deepdish/core/schema'
+import { schema } from '@deepdish/core/schema'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
 import { cookieResolver } from './resolver'
 
-const textSchema = createSchema((v) => v.string())
+const textSchema = schema((v) => v.string())
 
 const contracts = {
   text: {

--- a/apps/marketing/src/cms.ts
+++ b/apps/marketing/src/cms.ts
@@ -1,7 +1,7 @@
 import { getBaseUrl } from '@/lib/get-base-url'
+import { createSchema } from '@deepdish/core/schema'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
-import { createSchema } from '@deepdish/core/schema'
 import { cookieResolver } from './resolver'
 
 const textSchema = createSchema((v) => v.string())

--- a/apps/marketing/src/cms.ts
+++ b/apps/marketing/src/cms.ts
@@ -1,10 +1,10 @@
 import { getBaseUrl } from '@/lib/get-base-url'
 import { createComponents } from '@deepdish/ui/components'
 import { configure } from '@deepdish/ui/config'
-import * as v from 'valibot'
+import { createSchema } from '@deepdish/core/schema'
 import { cookieResolver } from './resolver'
 
-const textSchema = v.string()
+const textSchema = createSchema((v) => v.string())
 
 const contracts = {
   text: {

--- a/apps/marketing/src/resolver.ts
+++ b/apps/marketing/src/resolver.ts
@@ -1,4 +1,4 @@
-import { createSchema } from '@deepdish/core/schema'
+import { schema } from '@deepdish/core/schema'
 import { type Context, createResolver } from '@deepdish/resolvers'
 import type { NextRequest, NextResponse } from 'next/server'
 
@@ -69,7 +69,7 @@ export function hasCookie(request: NextRequest) {
 }
 
 export const cookieResolver = createResolver(
-  createSchema((v) => v.string()),
+  schema((v) => v.string()),
   {
     deriveKey,
   },

--- a/apps/marketing/src/resolver.ts
+++ b/apps/marketing/src/resolver.ts
@@ -1,6 +1,6 @@
+import { createSchema } from '@deepdish/core/schema'
 import { type Context, createResolver } from '@deepdish/resolvers'
 import type { NextRequest, NextResponse } from 'next/server'
-import * as v from 'valibot'
 
 const data = new Map<string, string>()
 const resolverCookie = '__deepdish_resolver'
@@ -68,6 +68,9 @@ export function hasCookie(request: NextRequest) {
   return cookie !== undefined
 }
 
-export const cookieResolver = createResolver(v.string(), {
-  deriveKey,
-})(loadValues, updateValues, listKeys)
+export const cookieResolver = createResolver(
+  createSchema((v) => v.string()),
+  {
+    deriveKey,
+  },
+)(loadValues, updateValues, listKeys)

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -27,10 +27,8 @@
     "@deepdish/nextjs": "workspace:0.9.0",
     "@deepdish/ui": "workspace:0.16.0",
     "@deepdish/workbench": "workspace:0.11.0",
-    "@valibot/to-json-schema": "1.0.0-rc.0",
     "react": "catalog:react",
-    "react-dom": "catalog:react",
-    "valibot": "1.0.0-rc.0"
+    "react-dom": "catalog:react"
   },
   "devDependencies": {
     "@tsconfig/create-react-app": "2.0.5",

--- a/packages/cms/src/cms.ts
+++ b/packages/cms/src/cms.ts
@@ -1,6 +1,6 @@
 import { createTypographyResolver } from '@deepdish-cloud/resolvers/typography'
 import { configure } from '@deepdish/ui/config'
-import * as v from 'valibot'
+import { schema } from '@deepdish/core/schema'
 import { deepdishMiddleware } from './middleware'
 import { ProviderContainer as DeepDishProvider } from './provider/container'
 
@@ -30,7 +30,7 @@ export const deepdish = async (config: DeepDishConfig) => {
           keys: () => Promise.resolve({ success: false, data: [] }),
           ...cloudTypographyResolver,
         },
-        schema: v.string(),
+        schema: schema((v) => v.string()),
       },
     },
     logging: {

--- a/packages/cms/src/cms.ts
+++ b/packages/cms/src/cms.ts
@@ -1,6 +1,6 @@
 import { createTypographyResolver } from '@deepdish-cloud/resolvers/typography'
-import { configure } from '@deepdish/ui/config'
 import { schema } from '@deepdish/core/schema'
+import { configure } from '@deepdish/ui/config'
 import { deepdishMiddleware } from './middleware'
 import { ProviderContainer as DeepDishProvider } from './provider/container'
 

--- a/packages/cms/src/provider/container.tsx
+++ b/packages/cms/src/provider/container.tsx
@@ -61,7 +61,9 @@ export function ProviderContainer(props: {
         throw new Error(`Contract '${name}' not found.`)
       }
 
-      return toJsonSchema(contract.schema)
+      return toJsonSchema(contract.schema, {
+        errorMode: 'ignore',
+      })
     },
     getKey: async (contractName: string, name: string) => {
       'use server'
@@ -95,7 +97,9 @@ export function ProviderContainer(props: {
       return {
         content,
         name,
-        schema: toJsonSchema(contract.schema),
+        schema: toJsonSchema(contract.schema, {
+          errorMode: 'ignore',
+        }),
       }
     },
     updateKey: async (contractName: string, name: string, content: unknown) => {

--- a/packages/cms/src/provider/container.tsx
+++ b/packages/cms/src/provider/container.tsx
@@ -1,5 +1,5 @@
+import { extractMetadata, serialize } from '@deepdish/core/schema'
 import { getContracts, getSettings } from '@deepdish/ui/config'
-import { toJsonSchema } from '@valibot/to-json-schema'
 import { Provider } from './provider'
 
 export function ProviderContainer(props: {
@@ -46,6 +46,23 @@ export function ProviderContainer(props: {
 
       return keysResult.data
     },
+    getContractMeta: async (name: string) => {
+      'use server'
+
+      const contractsResult = getContracts()
+
+      if (contractsResult.failure) {
+        throw contractsResult.failure
+      }
+
+      const contract = contractsResult.data[name]
+
+      if (!contract) {
+        throw new Error(`Contract '${name}' not found.`)
+      }
+
+      return extractMetadata(contract.schema)
+    },
     getContractSchema: async (name: string) => {
       'use server'
 
@@ -61,9 +78,7 @@ export function ProviderContainer(props: {
         throw new Error(`Contract '${name}' not found.`)
       }
 
-      return toJsonSchema(contract.schema, {
-        errorMode: 'ignore',
-      })
+      return serialize(contract.schema)
     },
     getKey: async (contractName: string, name: string) => {
       'use server'
@@ -97,9 +112,7 @@ export function ProviderContainer(props: {
       return {
         content,
         name,
-        schema: toJsonSchema(contract.schema, {
-          errorMode: 'ignore',
-        }),
+        schema: serialize(contract.schema),
       }
     },
     updateKey: async (contractName: string, name: string, content: unknown) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,8 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
+    "@valibot/to-json-schema": "1.0.0-rc.0",
+    "json-schema": "0.4.0",
     "mitt": "3.0.1",
     "react": "catalog:react",
     "valibot": "1.0.0-rc.0",
@@ -37,6 +39,7 @@
   },
   "devDependencies": {
     "@tsconfig/create-react-app": "2.0.5",
+    "@types/json-schema": "7.0.15",
     "@types/react": "catalog:react-18",
     "tsup": "catalog:repo"
   },

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test'
+import { createSchema, extractMetadata } from './schema'
+
+describe('extractMetadata', () => {
+  it('should extract metadata from a simple schema', () => {
+    const schema = createSchema((v, { meta }) =>
+      meta(v.string(), { rich: true }),
+    )
+
+    const result = extractMetadata(schema)
+    expect(result).toEqual({ rich: true })
+  })
+
+  it('should extract metadata from nested object schemas', () => {
+    const schema = createSchema((v, { required, rich }) => {
+      return v.object({
+        name: required(v.string()),
+        details: v.object({
+          age: required(v.number()),
+          bio: rich(v.string()),
+        }),
+      })
+    })
+
+    const result = extractMetadata(schema)
+    expect(result).toEqual({
+      name: { required: true },
+      'details.age': { required: true },
+      'details.bio': { rich: true },
+    })
+  })
+
+  it('should handle schemas without metadata', () => {
+    const schema = createSchema((v) =>
+      v.object({
+        name: v.string(),
+        age: v.number(),
+      }),
+    )
+
+    const result = extractMetadata(schema)
+    expect(result).toBeNull()
+  })
+})

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { schema, extractMetadata } from './schema'
+import { extractMetadata, schema } from './schema'
 
 describe('extractMetadata', () => {
   it('should extract metadata from a simple schema', () => {
@@ -8,7 +8,9 @@ describe('extractMetadata', () => {
     )
 
     const result = extractMetadata(simpleSchema)
-    expect(result).toEqual({ rich: true })
+    expect(result).toEqual({
+      root: { rich: true },
+    })
   })
 
   it('should extract metadata from nested object schemas', () => {
@@ -24,9 +26,9 @@ describe('extractMetadata', () => {
 
     const result = extractMetadata(nestedSchema)
     expect(result).toEqual({
-      name: { required: true },
-      'details.age': { required: true },
-      'details.bio': { rich: true },
+      'root.name': { required: true },
+      'root.details.age': { required: true },
+      'root.details.bio': { rich: true },
     })
   })
 
@@ -39,6 +41,6 @@ describe('extractMetadata', () => {
     )
 
     const result = extractMetadata(schemaWithoutMetadata)
-    expect(result).toBeNull()
+    expect(result).toBeEmptyObject()
   })
 })

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from 'bun:test'
-import { createSchema, extractMetadata } from './schema'
+import { schema, extractMetadata } from './schema'
 
 describe('extractMetadata', () => {
   it('should extract metadata from a simple schema', () => {
-    const schema = createSchema((v, { meta }) =>
+    const simpleSchema = schema((v, { meta }) =>
       meta(v.string(), { rich: true }),
     )
 
-    const result = extractMetadata(schema)
+    const result = extractMetadata(simpleSchema)
     expect(result).toEqual({ rich: true })
   })
 
   it('should extract metadata from nested object schemas', () => {
-    const schema = createSchema((v, { required, rich }) => {
+    const nestedSchema = schema((v, { required, rich }) => {
       return v.object({
         name: required(v.string()),
         details: v.object({
@@ -22,7 +22,7 @@ describe('extractMetadata', () => {
       })
     })
 
-    const result = extractMetadata(schema)
+    const result = extractMetadata(nestedSchema)
     expect(result).toEqual({
       name: { required: true },
       'details.age': { required: true },
@@ -31,14 +31,14 @@ describe('extractMetadata', () => {
   })
 
   it('should handle schemas without metadata', () => {
-    const schema = createSchema((v) =>
+    const schemaWithoutMetadata = schema((v) =>
       v.object({
         name: v.string(),
         age: v.number(),
       }),
     )
 
-    const result = extractMetadata(schema)
+    const result = extractMetadata(schemaWithoutMetadata)
     expect(result).toBeNull()
   })
 })

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,6 +1,86 @@
 import type { BaseIssue, BaseSchema, InferOutput } from 'valibot'
+import * as v from 'valibot'
+
+type SchemaUtils = {
+  meta: typeof meta
+  required: typeof required
+  rich: typeof rich
+}
+
+type Meta = {
+  required?: boolean
+  rich?: boolean
+}
 
 // biome-ignore lint/suspicious/noExplicitAny: generic schema type requires output type of any
 export type Schema<S = unknown> = BaseSchema<S, any, BaseIssue<unknown>>
 
 export type Value<S extends Schema> = InferOutput<S>
+
+export function createSchema(
+  buildSchema: (valibot: typeof v, utils: SchemaUtils) => Schema,
+) {
+  return buildSchema(v, { meta, required, rich })
+}
+
+export function extractMetadata<S extends Schema>(
+  valibotSchema: S,
+): Record<string, Meta> | Meta | null {
+  const result: Record<string, Meta> = {}
+  const root = ''
+
+  let isPrimitive = true
+
+  function traverse(schema: Schema, path: string[] = []) {
+    if ('pipe' in schema && Array.isArray(schema.pipe)) {
+      for (const pipeItem of schema.pipe) {
+        traverse(pipeItem as Schema, path)
+      }
+    }
+
+    if (
+      'entries' in schema &&
+      schema.entries &&
+      typeof schema.entries === 'object'
+    ) {
+      isPrimitive = false
+      const entries = schema.entries as Record<string, Schema>
+      for (const [key, value] of Object.entries(entries)) {
+        traverse(value, [...path, key])
+      }
+    }
+
+    if ('metadata' in schema && schema.metadata) {
+      const fullPath = path.join('.')
+      result[fullPath] = schema.metadata
+    }
+  }
+
+  traverse(valibotSchema)
+
+  if (isPrimitive && result[root]) {
+    return result[root]
+  }
+
+  if (!Object.keys(result).length) {
+    return null
+  }
+
+  return result
+}
+
+export function meta<S extends Schema>(schema: S, meta?: Meta) {
+  if (meta) {
+    return v.pipe(schema, v.metadata(meta))
+  }
+
+  return schema
+}
+
+export function required<S extends Schema>(schema: S) {
+  return meta(schema, { required: true })
+}
+
+export function rich<S extends Schema>(schema: S) {
+  return meta(schema, { rich: true })
+}

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,4 +1,6 @@
 import type { BaseIssue, BaseSchema, InferOutput } from 'valibot'
+import type { JSONSchema7 } from 'json-schema'
+import { toJsonSchema } from '@valibot/to-json-schema'
 import * as v from 'valibot'
 
 type SchemaUtils = {
@@ -66,6 +68,13 @@ export function required<S extends Schema>(schema: S) {
 
 export function rich<S extends Schema>(schema: S) {
   return meta(schema, { rich: true })
+}
+
+export function serialize<S extends Schema>(
+  schema: S,
+  errorMode?: 'ignore' | 'throw' | 'warn',
+): JSONSchema7 {
+  return toJsonSchema(schema, { errorMode: errorMode ?? 'ignore' })
 }
 
 export function schema(

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,6 +1,6 @@
-import type { BaseIssue, BaseSchema, InferOutput } from 'valibot'
-import type { JSONSchema7 } from 'json-schema'
 import { toJsonSchema } from '@valibot/to-json-schema'
+import type { JSONSchema7 } from 'json-schema'
+import type { BaseIssue, BaseSchema, InferOutput } from 'valibot'
 import * as v from 'valibot'
 
 type SchemaUtils = {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -17,12 +17,6 @@ export type Schema<S = unknown> = BaseSchema<S, any, BaseIssue<unknown>>
 
 export type Value<S extends Schema> = InferOutput<S>
 
-export function createSchema(
-  buildSchema: (valibot: typeof v, utils: SchemaUtils) => Schema,
-) {
-  return buildSchema(v, { meta, required, rich })
-}
-
 export function extractMetadata<S extends Schema>(
   valibotSchema: S,
 ): Record<string, Meta> | Meta | null {
@@ -83,4 +77,10 @@ export function required<S extends Schema>(schema: S) {
 
 export function rich<S extends Schema>(schema: S) {
   return meta(schema, { rich: true })
+}
+
+export function schema(
+  buildSchema: (valibot: typeof v, utils: SchemaUtils) => Schema,
+) {
+  return buildSchema(v, { meta, required, rich })
 }

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -53,7 +53,6 @@
     "@tiptap/pm": "2.11.5",
     "@tiptap/react": "2.11.5",
     "@tiptap/starter-kit": "2.11.5",
-    "@valibot/to-json-schema": "1.0.0-rc.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "0.475.0",

--- a/packages/workbench/src/mocks/data.ts
+++ b/packages/workbench/src/mocks/data.ts
@@ -1,32 +1,33 @@
-import { toJsonSchema } from '@valibot/to-json-schema'
-import * as v from 'valibot'
+import { extractMetadata, schema, serialize } from '@deepdish/core/schema'
 
-const blogSchema = v.object({
-  title: v.string(),
-  author: v.object({
-    name: v.string(),
-    email: v.string(),
+const blogSchema = schema((v, { rich }) =>
+  v.object({
+    title: v.string(),
+    author: v.object({
+      name: v.string(),
+      email: v.string(),
+      bio: rich(v.string()),
+    }),
+    body: rich(v.string()),
   }),
-  body: v.string(),
-})
+)
 
-const featureSchema = v.object({ name: v.string(), description: v.string() })
+const featureSchema = schema((v) =>
+  v.object({ name: v.string(), description: v.string() }),
+)
 
-const textSchema = v.string()
+const textSchema = schema((v, { required }) => required(v.string()))
 
 export const catalog = {
   blog: {
     schema: blogSchema,
-    serializedSchema: toJsonSchema(blogSchema, {
-      errorMode: 'ignore',
-    }),
+    serializedSchema: serialize(blogSchema),
     keys: {},
+    meta: extractMetadata(blogSchema),
   },
   feature: {
     schema: featureSchema,
-    serializedSchema: toJsonSchema(featureSchema, {
-      errorMode: 'ignore',
-    }),
+    serializedSchema: serialize(blogSchema),
     keys: {
       'home/feature-1': {
         name: 'Feature 1 Name',
@@ -37,15 +38,15 @@ export const catalog = {
         description: 'Feature 2 Description',
       },
     },
+    meta: extractMetadata(featureSchema),
   },
   text: {
     schema: textSchema,
-    serializedSchema: toJsonSchema(textSchema, {
-      errorMode: 'ignore',
-    }),
+    serializedSchema: serialize(blogSchema),
     keys: {
       'home/headline': 'Headline',
       'home/sub-headline': 'Sub-Headline',
     },
+    meta: extractMetadata(textSchema),
   },
 }

--- a/packages/workbench/src/mocks/data.ts
+++ b/packages/workbench/src/mocks/data.ts
@@ -17,12 +17,16 @@ const textSchema = v.string()
 export const catalog = {
   blog: {
     schema: blogSchema,
-    serializedSchema: toJsonSchema(blogSchema),
+    serializedSchema: toJsonSchema(blogSchema, {
+      errorMode: 'ignore',
+    }),
     keys: {},
   },
   feature: {
     schema: featureSchema,
-    serializedSchema: toJsonSchema(featureSchema),
+    serializedSchema: toJsonSchema(featureSchema, {
+      errorMode: 'ignore',
+    }),
     keys: {
       'home/feature-1': {
         name: 'Feature 1 Name',
@@ -36,7 +40,9 @@ export const catalog = {
   },
   text: {
     schema: textSchema,
-    serializedSchema: toJsonSchema(textSchema),
+    serializedSchema: toJsonSchema(textSchema, {
+      errorMode: 'ignore',
+    }),
     keys: {
       'home/headline': 'Headline',
       'home/sub-headline': 'Sub-Headline',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@deepdish/cms':
         specifier: workspace:0.9.0
         version: link:../../packages/cms
+      '@deepdish/core':
+        specifier: workspace:0.5.0
+        version: link:../../packages/core
       '@deepdish/nextjs':
         specifier: workspace:0.9.0
         version: link:../../packages/nextjs
@@ -134,9 +137,6 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
-      valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.5.4)
     devDependencies:
       '@types/node':
         specifier: 20.14.2
@@ -165,6 +165,9 @@ importers:
       '@deepdish/cms':
         specifier: workspace:0.9.0
         version: link:../../packages/cms
+      '@deepdish/core':
+        specifier: workspace:0.5.0
+        version: link:../../packages/core
       '@deepdish/nextjs':
         specifier: workspace:0.9.0
         version: link:../../packages/nextjs
@@ -219,9 +222,6 @@ importers:
       tailwindcss-animate:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@3.4.4)
-      valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.5.4)
     devDependencies:
       '@tsconfig/next':
         specifier: 2.0.3
@@ -10395,10 +10395,6 @@ snapshots:
       react: 19.0.0
 
   util-deprecate@1.0.2: {}
-
-  valibot@1.0.0-rc.0(typescript@5.5.4):
-    optionalDependencies:
-      typescript: 5.5.4
 
   valibot@1.0.0-rc.0(typescript@5.7.2):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,9 +268,6 @@ importers:
       '@deepdish/workbench':
         specifier: workspace:0.11.0
         version: link:../workbench
-      '@valibot/to-json-schema':
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(valibot@1.0.0-rc.0(typescript@5.7.3))
       next:
         specifier: catalog:peer-next
         version: 15.1.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -280,9 +277,6 @@ importers:
       react-dom:
         specifier: catalog:react
         version: 19.0.0(react@19.0.0)
-      valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.7.3)
     devDependencies:
       '@tsconfig/create-react-app':
         specifier: 2.0.5
@@ -296,6 +290,12 @@ importers:
 
   packages/core:
     dependencies:
+      '@valibot/to-json-schema':
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(valibot@1.0.0-rc.0(typescript@5.7.3))
+      json-schema:
+        specifier: 0.4.0
+        version: 0.4.0
       mitt:
         specifier: 3.0.1
         version: 3.0.1
@@ -312,6 +312,9 @@ importers:
       '@tsconfig/create-react-app':
         specifier: 2.0.5
         version: 2.0.5
+      '@types/json-schema':
+        specifier: 7.0.15
+        version: 7.0.15
       '@types/react':
         specifier: catalog:react-18
         version: 18.3.3
@@ -665,9 +668,6 @@ importers:
       '@tiptap/starter-kit':
         specifier: 2.11.5
         version: 2.11.5
-      '@valibot/to-json-schema':
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(valibot@1.0.0-rc.0(typescript@5.7.2))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -8121,10 +8121,6 @@ snapshots:
       '@types/node': 20.14.2
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@valibot/to-json-schema@1.0.0-rc.0(valibot@1.0.0-rc.0(typescript@5.7.2))':
-    dependencies:
-      valibot: 1.0.0-rc.0(typescript@5.7.2)
 
   '@valibot/to-json-schema@1.0.0-rc.0(valibot@1.0.0-rc.0(typescript@5.7.3))':
     dependencies:


### PR DESCRIPTION
Adds the `schema` helper to the `core` package. This lets developer build and annotate a schema without needing to import `valibot`. For example:

```ts
const blogSchema = schema((v, required) => required(v.string())
```

This also adds a `serialize` helper.

This also adds some stuff that'll be helpful for some upcoming Workbench work:
- error suppression to schema serialization
- metadata extraction

Resolved DEEP-238