### PR TITLE
feat(schema): add type inference to schema builder

### DIFF
--- a/.changeset/better-apples-count.md
+++ b/.changeset/better-apples-count.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/core": patch
+---
+
+Added type inference to schema builder.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,6 +1,6 @@
 import { toJsonSchema } from '@valibot/to-json-schema'
 import type { JSONSchema7 } from 'json-schema'
-import type { BaseIssue, BaseSchema, InferOutput } from 'valibot'
+import type { BaseIssue, BaseSchema, GenericSchema, InferOutput } from 'valibot'
 import * as v from 'valibot'
 
 type SchemaUtils = {
@@ -78,7 +78,7 @@ export function serialize<S extends Schema>(
 }
 
 export function schema<T>(
-  buildSchema: (valibot: typeof v, utils: SchemaUtils) => Schema<T>,
+  buildSchema: (valibot: typeof v, utils: SchemaUtils) => GenericSchema<T>,
 ) {
   return buildSchema(v, { meta, required, rich })
 }

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -77,8 +77,8 @@ export function serialize<S extends Schema>(
   return toJsonSchema(schema, { errorMode: errorMode ?? 'ignore' })
 }
 
-export function schema(
-  buildSchema: (valibot: typeof v, utils: SchemaUtils) => Schema,
+export function schema<T>(
+  buildSchema: (valibot: typeof v, utils: SchemaUtils) => Schema<T>,
 ) {
   return buildSchema(v, { meta, required, rich })
 }


### PR DESCRIPTION
This ensures that schemas built using the `schema` builder have the proper type inferred from the result.

This enhancement is particularly noticeable for created components whose `render` values now have the properly inferred type.