### PR TITLE
build(repo): update valibot to major release

### DIFF
--- a/.changeset/rich-readers-fold.md
+++ b/.changeset/rich-readers-fold.md
@@ -1,0 +1,9 @@
+---
+"@deepdish/resolvers": patch
+"@deepdish/workbench": patch
+"@deepdish/core": patch
+"@deepdish/menu": patch
+"@deepdish/ui": patch
+---
+
+Updated valibot to major release.

--- a/.changeset/rich-readers-fold.md
+++ b/.changeset/rich-readers-fold.md
@@ -4,6 +4,7 @@
 "@deepdish/core": patch
 "@deepdish/menu": patch
 "@deepdish/ui": patch
+"@deepdish/cli": patch
 ---
 
 Updated valibot to major release.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,7 +26,7 @@
     "@stricli/core": "1.1.1",
     "chalk": "5.4.1",
     "open": "10.1.0",
-    "valibot": "1.0.0-rc.0"
+    "valibot": "catalog:valibot"
   },
   "devDependencies": {
     "@types/node": "catalog:repo",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "json-schema": "0.4.0",
     "mitt": "3.0.1",
     "react": "catalog:react",
-    "valibot": "1.0.0-rc.0",
+    "valibot": "catalog:valibot",
     "zustand": "5.0.3"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@valibot/to-json-schema": "1.0.0-rc.0",
+    "@valibot/to-json-schema": "catalog:valibot",
     "json-schema": "0.4.0",
     "mitt": "3.0.1",
     "react": "catalog:react",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -34,7 +34,7 @@
     "tailwind-merge": "3.0.1",
     "tailwindcss": "4.0.3",
     "tailwindcss-animate": "1.0.7",
-    "valibot": "1.0.0-rc.0"
+    "valibot": "catalog:valibot"
   },
   "devDependencies": {
     "@tsconfig/create-react-app": "2.0.5",

--- a/packages/resolvers/package.json
+++ b/packages/resolvers/package.json
@@ -25,7 +25,7 @@
     "@byteslice/result": "0.1.0",
     "@deepdish/core": "workspace:0.5.0",
     "dataloader": "2.2.2",
-    "valibot": "1.0.0-rc.0"
+    "valibot": "catalog:valibot"
   },
   "devDependencies": {
     "@types/bun": "catalog:repo",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,7 @@
     "remark-rehype": "11.1.0",
     "server-only": "0.0.1",
     "unified": "11.0.5",
-    "valibot": "1.0.0-rc.0"
+    "valibot": "catalog:valibot"
   },
   "devDependencies": {
     "@tsconfig/create-react-app": "2.0.5",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -68,7 +68,7 @@
     "tailwind-merge": "catalog:tailwind",
     "tailwindcss": "catalog:tailwind",
     "tailwindcss-animate": "catalog:tailwind",
-    "valibot": "1.0.0-rc.0"
+    "valibot": "catalog:valibot"
   },
   "devDependencies": {
     "@tanstack/router-devtools": "1.106.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ catalogs:
       specifier: 1.0.7
       version: 1.0.7
   valibot:
+    '@valibot/to-json-schema':
+      specifier: 1.0.0
+      version: 1.0.0
     valibot:
       specifier: 1.0.0
       version: 1.0.0
@@ -314,8 +317,8 @@ importers:
   packages/core:
     dependencies:
       '@valibot/to-json-schema':
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(valibot@1.0.0(typescript@5.7.3))
+        specifier: catalog:valibot
+        version: 1.0.0(valibot@1.0.0(typescript@5.7.3))
       json-schema:
         specifier: 0.4.0
         version: 0.4.0
@@ -3373,10 +3376,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@valibot/to-json-schema@1.0.0-rc.0':
-    resolution: {integrity: sha512-F3WDgnPzcDs9Y8qZwU9qfPnEJBQ6lCMCFjI7VsMjAza6yAixGr4cZ50gOy6zniSCk49GkFvq2a6cBKfZjTpyOw==}
+  '@valibot/to-json-schema@1.0.0':
+    resolution: {integrity: sha512-/9crJgPptVsGCL6X+JPDQyaJwkalSZ/52WuF8DiRUxJgcmpNdzYRfZ+gqMEP8W3CTVfuMWPqqvIgfwJ97f9Etw==}
     peerDependencies:
-      valibot: ^1.0.0 || ^1.0.0-beta.5 || ^1.0.0-rc
+      valibot: ^1.0.0
 
   '@vitejs/plugin-react-swc@3.5.0':
     resolution: {integrity: sha512-1PrOvAaDpqlCV+Up8RkAh9qaiUjoDUcjtttyhXDKw53XA6Ve16SOp6cCOpRs8Dj8DqUQs6eTW5YkLcLJjrXAig==}
@@ -8168,7 +8171,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@valibot/to-json-schema@1.0.0-rc.0(valibot@1.0.0(typescript@5.7.3))':
+  '@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.7.3))':
     dependencies:
       valibot: 1.0.0(typescript@5.7.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,10 @@ catalogs:
     tailwindcss-animate:
       specifier: 1.0.7
       version: 1.0.7
+  valibot:
+    valibot:
+      specifier: 1.0.0
+      version: 1.0.0
   vite:
     '@vitejs/plugin-react-swc':
       specifier: 3.5.0
@@ -311,7 +315,7 @@ importers:
     dependencies:
       '@valibot/to-json-schema':
         specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(valibot@1.0.0-rc.0(typescript@5.7.3))
+        version: 1.0.0-rc.0(valibot@1.0.0(typescript@5.7.3))
       json-schema:
         specifier: 0.4.0
         version: 0.4.0
@@ -322,8 +326,8 @@ importers:
         specifier: catalog:react
         version: 19.0.0
       valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.7.3)
+        specifier: catalog:valibot
+        version: 1.0.0(typescript@5.7.3)
       zustand:
         specifier: 5.0.3
         version: 5.0.3(@types/react@18.3.3)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
@@ -386,8 +390,8 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@4.0.3)
       valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.7.2)
+        specifier: catalog:valibot
+        version: 1.0.0(typescript@5.7.2)
     devDependencies:
       '@tsconfig/create-react-app':
         specifier: 2.0.5
@@ -457,8 +461,8 @@ importers:
         specifier: 2.2.2
         version: 2.2.2
       valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.7.2)
+        specifier: catalog:valibot
+        version: 1.0.0(typescript@5.7.2)
     devDependencies:
       '@types/bun':
         specifier: catalog:repo
@@ -567,8 +571,8 @@ importers:
         specifier: 11.0.5
         version: 11.0.5
       valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.7.2)
+        specifier: catalog:valibot
+        version: 1.0.0(typescript@5.7.2)
     devDependencies:
       '@tsconfig/create-react-app':
         specifier: 2.0.5
@@ -733,8 +737,8 @@ importers:
         specifier: catalog:tailwind
         version: 1.0.7(tailwindcss@4.0.3)
       valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.7.2)
+        specifier: catalog:valibot
+        version: 1.0.0(typescript@5.7.2)
     devDependencies:
       '@tanstack/router-devtools':
         specifier: 1.106.0
@@ -5363,8 +5367,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@1.0.0-rc.0:
-    resolution: {integrity: sha512-9ZUrOXOejY/WaIn8p0Z469R1qBAwNJeqq8jzOIDsl1qR8gqtObHQmyHLFli0UCkcGiTco5kH6/KPLWsTWE9b2g==}
+  valibot@1.0.0:
+    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -8164,9 +8168,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@valibot/to-json-schema@1.0.0-rc.0(valibot@1.0.0-rc.0(typescript@5.7.3))':
+  '@valibot/to-json-schema@1.0.0-rc.0(valibot@1.0.0(typescript@5.7.3))':
     dependencies:
-      valibot: 1.0.0-rc.0(typescript@5.7.3)
+      valibot: 1.0.0(typescript@5.7.3)
 
   '@vitejs/plugin-react-swc@3.5.0(@swc/helpers@0.5.15)(vite@6.1.0(@types/node@22.13.11)(jiti@2.4.2)(lightningcss@1.29.1)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
@@ -10436,11 +10440,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.0.0-rc.0(typescript@5.7.2):
+  valibot@1.0.0(typescript@5.7.2):
     optionalDependencies:
       typescript: 5.7.2
 
-  valibot@1.0.0-rc.0(typescript@5.7.3):
+  valibot@1.0.0(typescript@5.7.3):
     optionalDependencies:
       typescript: 5.7.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: 10.1.0
         version: 10.1.0
       valibot:
-        specifier: 1.0.0-rc.0
-        version: 1.0.0-rc.0(typescript@5.7.2)
+        specifier: catalog:valibot
+        version: 1.0.0(typescript@5.7.2)
     devDependencies:
       '@types/node':
         specifier: catalog:repo
@@ -3619,7 +3619,6 @@ packages:
 
   bun@1.2.4:
     resolution: {integrity: sha512-ZY0EZ/UKqheaLeAtMsfJA6jWoWvV9HAtfFaOJSmS3LrNpFKs1Sg5fZLSsczN1h3a+Dtheo4O3p3ZYWrf40kRGw==}
-    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ catalogs:
 
   valibot:
     valibot: 1.0.0
+    "@valibot/to-json-schema": 1.0.0
 
   vite:
     vite: 6.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,9 @@ catalogs:
     "@tailwindcss/postcss": 4.0.3
     "@tailwindcss/vite": 4.0.3
 
+  valibot:
+    valibot: 1.0.0
+
   vite:
     vite: 6.1.0
     "@vitejs/plugin-react-swc": 3.5.0


### PR DESCRIPTION
[Valibot](https://github.com/fabian-hiller/valibot/releases/tag/v1.0.0) and [to-json-schema](https://github.com/fabian-hiller/valibot/releases/tag/v1.0.0-to-json-schema) have hit their v1 major release. Let the updating commence.