### PR TITLE
feat(cli): implement logout command

### DIFF
--- a/.changeset/upset-grapes-look.md
+++ b/.changeset/upset-grapes-look.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/cli": minor
+---
+
+Implemented `cloud auth logout` command.

--- a/apps/cli/src/auth/exchange.ts
+++ b/apps/cli/src/auth/exchange.ts
@@ -7,8 +7,6 @@ const configSchema = v.object({
   clientId: v.string(),
 })
 
-const jwtSchema = v.string()
-
 const tokenSchema = v.object({
   idToken: v.string(),
   expiresIn: v.number(),
@@ -71,24 +69,4 @@ export async function exchangeTokenForTicket(
 
   const json = await response.json()
   return v.parse(ticketSchema, json)
-}
-
-export async function createSessionJwt(
-  baseDeepdishCloudUrl: string,
-  token: string,
-  sessionId: string,
-) {
-  const response = await fetch(`${baseDeepdishCloudUrl}/jwt`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      sessionId,
-    }),
-  })
-
-  const json = await response.json()
-  return v.parse(jwtSchema, json)
 }

--- a/apps/cli/src/auth/session.ts
+++ b/apps/cli/src/auth/session.ts
@@ -1,0 +1,44 @@
+import * as v from 'valibot'
+
+const jwtSchema = v.string()
+
+export async function createSessionJwt(
+  baseDeepdishCloudUrl: string,
+  token: string,
+  sessionId: string,
+) {
+  const response = await fetch(`${baseDeepdishCloudUrl}/jwt`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      sessionId,
+    }),
+  })
+
+  const json = await response.json()
+  return v.parse(jwtSchema, json)
+}
+
+export async function revokeSession(
+  baseDeepdishCloudUrl: string,
+  token: string,
+  sessionId: string,
+) {
+  const response = await fetch(`${baseDeepdishCloudUrl}/session`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      sessionId,
+    }),
+  })
+
+  if (response.status !== 204) {
+    throw new Error('Failed to revoke session.')
+  }
+}

--- a/apps/cli/src/auth/storage.ts
+++ b/apps/cli/src/auth/storage.ts
@@ -39,7 +39,15 @@ export function getDeepDishDirectory(context: LocalContext) {
 
 export async function purgeCredentialsFile(context: LocalContext) {
   const filePath = getCredentialsFilePath(context)
-  await context.fsPromise.unlink(filePath)
+
+  const exists = await context.fsPromise
+    .stat(filePath)
+    .then(() => true)
+    .catch(() => false)
+
+  if (exists) {
+    await context.fsPromise.unlink(filePath)
+  }
 }
 
 export async function readCredentialsFile(context: LocalContext) {

--- a/apps/cli/src/auth/storage.ts
+++ b/apps/cli/src/auth/storage.ts
@@ -1,6 +1,29 @@
 import type { LocalContext } from '@/context'
+import * as v from 'valibot'
 
-export function getJwtDirectory(context: LocalContext) {
+const credentialsSchema = v.object({
+  jwt: v.string(),
+  sessionId: v.string(),
+})
+
+async function ensureDirectoryExists(context: LocalContext, path: string) {
+  const exists = await context.fsPromise
+    .stat(path)
+    .then(() => true)
+    .catch(() => false)
+
+  if (!exists) {
+    await context.fsPromise.mkdir(path, { recursive: true })
+  }
+}
+
+export function getCredentialsFilePath(context: LocalContext) {
+  const directory = getDeepDishDirectory(context)
+
+  return `${directory}/credentials`
+}
+
+export function getDeepDishDirectory(context: LocalContext) {
   if (!context.path) {
     throw new Error('No `path` found in context.')
   }
@@ -14,30 +37,31 @@ export function getJwtDirectory(context: LocalContext) {
   return context.path.join(home, '.deepdish')
 }
 
-export function getJwtFilePath(context: LocalContext) {
-  const directory = getJwtDirectory(context)
-
-  return `${directory}/jwt`
+export async function purgeCredentialsFile(context: LocalContext) {
+  const filePath = getCredentialsFilePath(context)
+  await context.fsPromise.unlink(filePath)
 }
 
-export async function readJwt(context: LocalContext) {
-  const path = getJwtFilePath(context)
+export async function readCredentialsFile(context: LocalContext) {
+  const filePath = getCredentialsFilePath(context)
+  const content = await context.fsPromise.readFile(filePath, 'utf8')
 
-  return await context.fsPromise.readFile(path, 'utf8')
+  return v.parse(credentialsSchema, JSON.parse(content))
 }
 
-export async function writeJwt(context: LocalContext, jwt: string) {
-  const directory = getJwtDirectory(context)
-  const filePath = getJwtFilePath(context)
+export async function saveCredentialsFile(
+  context: LocalContext,
+  token: string,
+  sessionId: string,
+) {
+  const filePath = getCredentialsFilePath(context)
+  await ensureDirectoryExists(context, getDeepDishDirectory(context))
 
-  const exists = await context.fsPromise
-    .stat(filePath)
-    .then(() => true)
-    .catch(() => false)
-
-  if (!exists) {
-    await context.fsPromise.mkdir(directory, { recursive: true })
-  }
-
-  await context.fsPromise.writeFile(filePath, jwt)
+  await context.fsPromise.writeFile(
+    filePath,
+    JSON.stringify({
+      jwt: token,
+      sessionId,
+    }),
+  )
 }

--- a/apps/cli/src/commands/cloud/auth/commands.ts
+++ b/apps/cli/src/commands/cloud/auth/commands.ts
@@ -16,6 +16,22 @@ export const cloudAuthLogin = buildCommand({
   },
 })
 
+export const cloudAuthLogout = buildCommand({
+  loader: async () => {
+    const { logout } = await import('./implementation')
+    return logout
+  },
+  parameters: {
+    positional: {
+      kind: 'tuple',
+      parameters: [],
+    },
+  },
+  docs: {
+    brief: 'Log out of an existing account',
+  },
+})
+
 export const cloudAuthSignup = buildCommand({
   loader: async () => {
     const { signup } = await import('./implementation')
@@ -35,6 +51,7 @@ export const cloudAuthSignup = buildCommand({
 export const cloudAuthRoutes = buildRouteMap({
   routes: {
     login: cloudAuthLogin,
+    logout: cloudAuthLogout,
     signup: cloudAuthSignup,
   },
   docs: {

--- a/apps/cli/src/commands/cloud/auth/implementation.ts
+++ b/apps/cli/src/commands/cloud/auth/implementation.ts
@@ -6,13 +6,17 @@ import {
 import { createClerk, createSignIn } from '@/auth/clerk'
 import {
   type Config,
-  createSessionJwt,
   exchangeCallbackCodeForToken,
   exchangeTokenForTicket,
   getConfig,
 } from '@/auth/exchange'
 import { generateOAuthState, openAuthorizeUrl } from '@/auth/oauth'
-import { writeJwt } from '@/auth/storage'
+import { createSessionJwt, revokeSession } from '@/auth/session'
+import {
+  purgeCredentialsFile,
+  readCredentialsFile,
+  saveCredentialsFile,
+} from '@/auth/storage'
 import type { LocalContext } from '@/context'
 import { env } from '@/env'
 import { withResult } from '@byteslice/result'
@@ -84,9 +88,9 @@ async function signInAndSaveJwt(
   }
 
   const write = await withResult(
-    () => writeJwt(context, jwt.data),
+    () => saveCredentialsFile(context, jwt.data, signIn.data.createdSessionId),
     (err) =>
-      new Error('Failed to save the session JWT to disk', {
+      new Error('Failed to save your credentials to disk', {
         cause: err.message,
       }),
   )
@@ -131,10 +135,56 @@ export async function login(this: LocalContext): Promise<void> {
     console.log(
       chalk.red('There was an error logging in. Please try again soon.'),
     )
+
     throw result.failure
   }
 
   console.log(chalk.green('Success! You are now logged in.'))
+}
+
+export async function logout(this: LocalContext): Promise<void> {
+  const credentials = await withResult(
+    () => readCredentialsFile(this),
+    (err) => err,
+  )
+
+  if (credentials.failure) {
+    console.log(
+      chalk.red(
+        'There was an issue reading your cedentials. You are probably already logged out.',
+      ),
+    )
+    return
+  }
+
+  const config = await withResult(
+    () => getConfig(env.BASE_DEEPDISH_CLOUD_URL),
+    (err) => err,
+  )
+
+  if (config.failure) {
+    throw config.failure
+  }
+
+  const result = await withResult(
+    async () => {
+      await revokeSession(
+        env.BASE_DEEPDISH_CLOUD_URL,
+        credentials.data.jwt,
+        credentials.data.sessionId,
+      )
+
+      await purgeCredentialsFile(this)
+    },
+
+    (err) => err,
+  )
+
+  if (result.failure) {
+    throw result.failure
+  }
+
+  console.log(chalk.green('Success! You are now logged out.'))
 }
 
 export async function signup(this: LocalContext): Promise<void> {

--- a/apps/cli/src/commands/cloud/auth/implementation.ts
+++ b/apps/cli/src/commands/cloud/auth/implementation.ts
@@ -151,7 +151,7 @@ export async function logout(this: LocalContext): Promise<void> {
   if (credentials.failure) {
     console.log(
       chalk.red(
-        'There was an issue reading your cedentials. You are probably already logged out.',
+        'There was an issue reading your credentials. You are probably already logged out.',
       ),
     )
     return

--- a/apps/cli/src/commands/cloud/auth/implementation.ts
+++ b/apps/cli/src/commands/cloud/auth/implementation.ts
@@ -166,22 +166,31 @@ export async function logout(this: LocalContext): Promise<void> {
     throw config.failure
   }
 
-  const result = await withResult(
-    async () => {
-      await revokeSession(
+  const revocation = await withResult(
+    async () =>
+      revokeSession(
         env.BASE_DEEPDISH_CLOUD_URL,
         credentials.data.jwt,
         credentials.data.sessionId,
-      )
-
-      await purgeCredentialsFile(this)
-    },
-
+      ),
     (err) => err,
   )
 
-  if (result.failure) {
-    throw result.failure
+  if (revocation.failure) {
+    console.log(
+      chalk.yellow(
+        'There was an issue revoking your session. You are probably already logged out. Purging credentials file...',
+      ),
+    )
+  }
+
+  const purge = await withResult(
+    async () => purgeCredentialsFile(this),
+    (err) => err,
+  )
+
+  if (purge.failure) {
+    throw purge.failure
   }
 
   console.log(chalk.green('Success! You are now logged out.'))


### PR DESCRIPTION
Adds the `logout` functionality. This also refactors the token storage. A `credentials` JSON file is now stored, which includes both the session ID and JWT.

Resolves DEEP-272