### PR TITLE
fix(workbench): ensure undefined meta works as expected

### DIFF
--- a/.changeset/chilly-eggs-brush.md
+++ b/.changeset/chilly-eggs-brush.md
@@ -1,0 +1,5 @@
+---
+"@deepdish/workbench": patch
+---
+
+Added undefined meta handling.

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -33,14 +33,19 @@ describe('extractMetadata', () => {
   })
 
   it('should handle schemas without metadata', () => {
-    const schemaWithoutMetadata = schema((v) =>
+    const objectSchemaWithoutMetadata = schema((v) =>
       v.object({
         name: v.string(),
         age: v.number(),
       }),
     )
 
-    const result = extractMetadata(schemaWithoutMetadata)
-    expect(result).toBeEmptyObject()
+    expect(extractMetadata(objectSchemaWithoutMetadata)).toBeEmptyObject()
+
+    const stringSchemaWithoutMetadata = schema((v) => v.string())
+    expect(extractMetadata(stringSchemaWithoutMetadata)).toBeEmptyObject()
+
+    const arraySchemaWithoutMetadata = schema((v) => v.array(v.string()))
+    expect(extractMetadata(arraySchemaWithoutMetadata)).toBeEmptyObject()
   })
 })

--- a/packages/workbench/src/components/json-schema-form/dynamic-form.tsx
+++ b/packages/workbench/src/components/json-schema-form/dynamic-form.tsx
@@ -21,7 +21,7 @@ function renderFields(
   register: UseFormRegister<FieldValues>,
   control: Control<FieldValues>,
   parentKey: string,
-  meta: Record<string, Meta>,
+  meta: Record<string, Meta | undefined>,
 ) {
   return Object.entries(properties).map(([key, subSchema]) => {
     if (typeof subSchema === 'boolean') {
@@ -215,7 +215,7 @@ export function DynamicForm(props: {
   contentRootKey: string
   onSubmit: (content: Content) => void
   schema: JSONSchema7
-  meta: Record<string, Meta>
+  meta: Record<string, Meta | undefined>
   uniqueId: string
 }) {
   const defaultValues: FieldValues = useMemo(() => {

--- a/packages/workbench/src/components/json-schema-form/index.tsx
+++ b/packages/workbench/src/components/json-schema-form/index.tsx
@@ -12,7 +12,7 @@ export function JsonSchemaForm(props: {
   onSubmit: (content: Content) => Promise<void>
   schema: JSONSchema7
   uniqueId: string
-  meta: Record<string, Meta>
+  meta: Record<string, Meta | undefined>
 }) {
   const initialUniqueId = useRef<string>(props.uniqueId)
   const [shouldRender, setShouldRender] = useState<boolean>(false)

--- a/packages/workbench/src/components/json-schema-form/simple-form.tsx
+++ b/packages/workbench/src/components/json-schema-form/simple-form.tsx
@@ -13,7 +13,7 @@ function Wrapper(props: {
 
 export function SimpleNumberForm(props: {
   content: number
-  meta: Meta
+  meta?: Meta
   onSubmit: (content: Content) => Promise<void>
   uniqueId: string
 }) {
@@ -47,7 +47,7 @@ export function SimpleNumberForm(props: {
 
 export function SimpleTextForm(props: {
   content: string
-  meta: Meta
+  meta?: Meta
   onSubmit: (content: Content) => void
   uniqueId: string
 }) {
@@ -62,7 +62,7 @@ export function SimpleTextForm(props: {
 
   return (
     <Wrapper>
-      {props.meta.rich ? (
+      {props.meta?.rich ? (
         <RichText
           content={value || ''}
           uniqueId={props.uniqueId}


### PR DESCRIPTION
I noticed an issue where a simple string schema defined without any `meta` was breaking the Workbench. I loosed the types a bit and added some optional property accessors.